### PR TITLE
refactor(config): remove deps for aurelia modal repo

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,7 +22,6 @@ System.config({
     "aurelia-framework": "github:aurelia/framework@0.13.3",
     "aurelia-metadata": "github:aurelia/metadata@0.7.0",
     "aurelia-templating": "github:aurelia/templating@0.13.11",
-    "aurelia/modal": "github:aurelia/dialog@master",
     "babel": "npm:babel-core@5.7.4",
     "babel-runtime": "npm:babel-runtime@5.7.0",
     "core-js": "npm:core-js@0.9.18",
@@ -57,12 +56,6 @@ System.config({
     },
     "github:aurelia/metadata@0.7.0": {
       "core-js": "npm:core-js@0.9.18"
-    },
-    "github:aurelia/modal@0.1.0": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.0",
-      "aurelia-framework": "github:aurelia/framework@0.13.3",
-      "aurelia-metadata": "github:aurelia/metadata@0.7.0",
-      "aurelia-templating": "github:aurelia/templating@0.13.11"
     },
     "github:aurelia/templating@0.13.11": {
       "aurelia-binding": "github:aurelia/binding@0.8.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.9.0",
       "aurelia-framework": "github:aurelia/framework@^0.13.3",
       "aurelia-metadata": "github:aurelia/metadata@^0.7.0",
-      "aurelia-templating": "github:aurelia/templating@^0.13.5",
-      "aurelia/modal": "github:aurelia/dialog@master"
+      "aurelia-templating": "github:aurelia/templating@^0.13.5"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.1.13",


### PR DESCRIPTION
Just a small tidy up of dependencies.

`config.js` and `package.json` had dependencies on aurelia/modal (which is now the dialog repo). I have removed these as they are invalid here.