### PR TITLE
fix(cancel): allows cancelling dialog without throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,21 @@ There are a few ways you can take advantage of the Aurelia dialog.
       this.dialogService = dialogService;
     }
     submit(){
-      this.dialogService.open({ viewModel: Prompt, model: 'Good or Bad?'}).then(() => {
-        console.log('good');
-      }).catch(() => {
-        console.log('bad');
+      this.dialogService.open({ viewModel: Prompt, model: 'Good or Bad?'}).then(response => {
+        if (!response.wasCancelled) {
+          console.log('good');
+        } else {
+          console.log('bad');
+        }
+        console.log(response.output);
       });
     }
   }
   ```
 
-  This will open a prompt that `resolve`s if the user clicks ok.  If the user clicks out, clicks cancel, or clicks the 'x' in the top right it will `reject` the promise.
+  This will open a prompt and return a promise that `resolve`s when closed.  If the user clicks out, clicks cancel, or clicks the 'x' in the top right it will still `resolve` the promise but will have a property on the response `wasCancelled` to allow the developer to handle cancelled dialogs.
+
+  There is also an `output` property that gets returned with the outcome of the user action if one was taken.
 
 2. You can create your own view / view-model and use the dialog service to call it from your app's view-model -
 
@@ -134,10 +139,13 @@ There are a few ways you can take advantage of the Aurelia dialog.
     }
     person = { firstName: 'Wade', middleName: 'Owen', lastName: 'Watts' };
     submit(){
-      this.dialogService.open({ viewModel: EditPerson, model: this.person}).then(() => {
-        console.log('edited');
-      }).catch(() => {
-        console.log('didnt edit');
+      this.dialogService.open({ viewModel: EditPerson, model: this.person}).then(response => {
+        if (!response.wasCancelled) {
+          console.log('good');
+        } else {
+          console.log('bad');
+        }
+        console.log(response.output);
       });
     }
   }

--- a/build/paths.js
+++ b/build/paths.js
@@ -11,6 +11,7 @@ module.exports = {
   style: 'styles/**/*.css',
   less: appRoot + 'styles/**/*.less',
   output: 'dist/',
+  sample: 'sample',
   doc:'./doc',
   e2eSpecsSrc: 'test/e2e/src/*.js',
   e2eSpecsDist: 'test/e2e/dist/',

--- a/build/tasks/serve.js
+++ b/build/tasks/serve.js
@@ -1,0 +1,20 @@
+var gulp = require('gulp');
+var browserSync = require('browser-sync');
+var path = require('path');
+var paths = require('../paths');
+
+// this task utilizes the browsersync plugin
+// to create a dev server instance
+// at http://localhost:9000
+gulp.task('serve', ['build'], function(done) {
+  var bs = browserSync.create('Sample server');
+
+  bs.init({
+    server: {
+      baseDir: paths.sample,
+      routes: {
+        '/aurelia-dialog': path.join(paths.output, 'amd')
+      },
+    },
+  }, done);
+});

--- a/build/tasks/watch.js
+++ b/build/tasks/watch.js
@@ -1,0 +1,22 @@
+var gulp = require('gulp');
+var browserSync = require('browser-sync');
+var paths = require('../paths');
+
+// outputs changes to files to the console
+function reportChange(event) {
+  console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
+}
+
+// this task wil watch for changes
+// to js, html, and css files and call the
+// reportChange method. Also, by depending on the
+// serve task, it will instantiate a browserSync session
+gulp.task('watch', ['serve'], function() {
+  var bs = browserSync.get('Sample server');
+
+  gulp.watch(paths.source, ['build-amd', bs.reload]).on('change', reportChange);
+  gulp.watch(paths.html, ['build-html-amd', bs.reload]).on('change', reportChange);
+  gulp.watch(paths.style, bs.reload).on('change', reportChange);
+  gulp.watch(paths.sample + '/*', bs.reload).on('change', reportChange);
+  gulp.watch(paths.sample + '/src/**/*', bs.reload).on('change', reportChange);
+});

--- a/config.js
+++ b/config.js
@@ -15,33 +15,34 @@ System.config({
   },
 
   map: {
-    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.0",
+    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
     "aurelia-framework": "github:aurelia/framework@0.16.0",
     "aurelia-metadata": "github:aurelia/metadata@0.8.0",
-    "aurelia-templating": "github:aurelia/templating@0.15.0",
-    "babel": "npm:babel-core@5.8.22",
-    "babel-runtime": "npm:babel-runtime@5.8.20",
-    "core-js": "npm:core-js@1.1.1",
-    "github:aurelia/binding@0.9.0": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.0",
+    "aurelia-templating": "github:aurelia/templating@0.15.3",
+    "babel": "npm:babel-core@5.8.25",
+    "babel-runtime": "npm:babel-runtime@5.8.24",
+    "core-js": "npm:core-js@1.1.4",
+    "text": "github:systemjs/plugin-text@0.0.2",
+    "github:aurelia/binding@0.9.1": {
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
       "aurelia-metadata": "github:aurelia/metadata@0.8.0",
       "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/dependency-injection@0.10.0": {
+    "github:aurelia/dependency-injection@0.10.1": {
       "aurelia-logging": "github:aurelia/logging@0.7.0",
       "aurelia-metadata": "github:aurelia/metadata@0.8.0",
       "core-js": "npm:core-js@0.9.18"
     },
     "github:aurelia/framework@0.16.0": {
-      "aurelia-binding": "github:aurelia/binding@0.9.0",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.0",
+      "aurelia-binding": "github:aurelia/binding@0.9.1",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
       "aurelia-loader": "github:aurelia/loader@0.9.0",
       "aurelia-logging": "github:aurelia/logging@0.7.0",
       "aurelia-metadata": "github:aurelia/metadata@0.8.0",
       "aurelia-path": "github:aurelia/path@0.9.0",
       "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
-      "aurelia-templating": "github:aurelia/templating@0.15.0",
+      "aurelia-templating": "github:aurelia/templating@0.15.3",
       "core-js": "npm:core-js@0.9.18"
     },
     "github:aurelia/loader@0.9.0": {
@@ -53,9 +54,9 @@ System.config({
     "github:aurelia/metadata@0.8.0": {
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/templating@0.15.0": {
-      "aurelia-binding": "github:aurelia/binding@0.9.0",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.0",
+    "github:aurelia/templating@0.15.3": {
+      "aurelia-binding": "github:aurelia/binding@0.9.1",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
       "aurelia-html-template-element": "github:aurelia/html-template-element@0.3.0",
       "aurelia-loader": "github:aurelia/loader@0.9.0",
       "aurelia-logging": "github:aurelia/logging@0.7.0",
@@ -67,7 +68,7 @@ System.config({
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
     },
-    "npm:babel-runtime@5.8.20": {
+    "npm:babel-runtime@5.8.24": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:core-js@0.9.18": {
@@ -75,7 +76,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
-    "npm:core-js@1.1.1": {
+    "npm:core-js@1.1.4": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "author": "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)",
-  "main": "dist/commonjs/index.js",
+  "main": "dist/amd/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/aurelia/dialog"
@@ -29,18 +29,20 @@
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.10.0",
       "aurelia-framework": "github:aurelia/framework@^0.16.0",
       "aurelia-metadata": "github:aurelia/metadata@^0.8.0",
-      "aurelia-templating": "github:aurelia/templating@^0.15.0"
+      "aurelia-templating": "github:aurelia/templating@^0.15.3",
+      "text": "github:systemjs/plugin-text@^0.0.2"
     },
     "devDependencies": {
-      "babel": "npm:babel-core@^5.8.22",
-      "babel-runtime": "npm:babel-runtime@^5.8.20",
-      "core-js": "npm:core-js@^1.1.0"
+      "babel": "npm:babel-core@^5.8.24",
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4"
     }
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.12",
     "babel-dts-generator": "^0.2.9",
     "babel-eslint": "^4.1.1",
+    "browser-sync": "^2.9.4",
     "conventional-changelog": "^0.4.2",
     "del": "^1.2.1",
     "event-stream": "^3.3.1",
@@ -57,7 +59,7 @@
     "gulp-typedoc": "^1.2.1",
     "gulp-typedoc-extractor": "0.0.8",
     "jasmine-core": "^2.3.4",
-    "jspm": "^0.16.0",
+    "jspm": "^0.16.6",
     "karma": "^0.13.9",
     "karma-babel-preprocessor": "^5.2.2",
     "karma-chrome-launcher": "^0.2.0",

--- a/sample/config.js
+++ b/sample/config.js
@@ -1,0 +1,170 @@
+System.config({
+  baseURL: "/",
+  defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
+    "optional": [
+      "runtime",
+      "optimisation.modules.system",
+      "es7.decorators",
+      "es7.classProperties"
+    ]
+  },
+  paths: {
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
+  },
+
+  packages: {
+    "/aurelia-dialog": {
+      "main": "index",
+      "dependencies": {
+        "aurelia-framework": "github:aurelia/framework@0.16.0",
+        "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.10.1",
+        "aurelia-metadata": "github:aurelia/metadata@^0.8.0",
+        "aurelia-templating": "github:aurelia/templating@^0.15.3"
+      }
+    }
+  },
+
+  map: {
+    "aurelia-bootstrapper": "github:aurelia/bootstrapper@0.17.0",
+    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+    "aurelia-framework": "github:aurelia/framework@0.16.0",
+    "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+    "aurelia-templating": "github:aurelia/templating@0.15.3",
+    "babel": "npm:babel-core@5.8.25",
+    "babel-runtime": "npm:babel-runtime@5.8.24",
+    "core-js": "npm:core-js@1.1.4",
+    "font-awesome": "npm:font-awesome@4.4.0",
+    "text": "github:systemjs/plugin-text@0.0.2",
+    "twbs/bootstrap": "github:twbs/bootstrap@3.3.5",
+    "github:aurelia/binding@0.9.1": {
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/bootstrapper@0.17.0": {
+      "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.8.0",
+      "aurelia-framework": "github:aurelia/framework@0.16.0",
+      "aurelia-history": "github:aurelia/history@0.7.0",
+      "aurelia-history-browser": "github:aurelia/history-browser@0.8.0",
+      "aurelia-loader-default": "github:aurelia/loader-default@0.10.0",
+      "aurelia-logging-console": "github:aurelia/logging-console@0.7.1",
+      "aurelia-router": "github:aurelia/router@0.12.0",
+      "aurelia-templating": "github:aurelia/templating@0.15.3",
+      "aurelia-templating-binding": "github:aurelia/templating-binding@0.15.0",
+      "aurelia-templating-resources": "github:aurelia/templating-resources@0.15.2",
+      "aurelia-templating-router": "github:aurelia/templating-router@0.16.1",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/dependency-injection@0.10.1": {
+      "aurelia-logging": "github:aurelia/logging@0.7.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/event-aggregator@0.8.0": {
+      "aurelia-logging": "github:aurelia/logging@0.7.0"
+    },
+    "github:aurelia/framework@0.16.0": {
+      "aurelia-binding": "github:aurelia/binding@0.9.1",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+      "aurelia-loader": "github:aurelia/loader@0.9.0",
+      "aurelia-logging": "github:aurelia/logging@0.7.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
+      "aurelia-templating": "github:aurelia/templating@0.15.3",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/history-browser@0.8.0": {
+      "aurelia-history": "github:aurelia/history@0.7.0",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/loader-default@0.10.0": {
+      "aurelia-loader": "github:aurelia/loader@0.9.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0"
+    },
+    "github:aurelia/loader@0.9.0": {
+      "aurelia-html-template-element": "github:aurelia/html-template-element@0.3.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "core-js": "github:zloirock/core-js@0.8.4"
+    },
+    "github:aurelia/logging-console@0.7.1": {
+      "aurelia-logging": "github:aurelia/logging@0.7.0"
+    },
+    "github:aurelia/metadata@0.8.0": {
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/route-recognizer@0.7.0": {
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/router@0.12.0": {
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+      "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.8.0",
+      "aurelia-history": "github:aurelia/history@0.7.0",
+      "aurelia-logging": "github:aurelia/logging@0.7.0",
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "aurelia-route-recognizer": "github:aurelia/route-recognizer@0.7.0",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/templating-binding@0.15.0": {
+      "aurelia-binding": "github:aurelia/binding@0.9.1",
+      "aurelia-logging": "github:aurelia/logging@0.7.0",
+      "aurelia-templating": "github:aurelia/templating@0.15.3"
+    },
+    "github:aurelia/templating-resources@0.15.2": {
+      "aurelia-binding": "github:aurelia/binding@0.9.1",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+      "aurelia-loader": "github:aurelia/loader@0.9.0",
+      "aurelia-logging": "github:aurelia/logging@0.7.0",
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
+      "aurelia-templating": "github:aurelia/templating@0.15.3",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:aurelia/templating-router@0.16.1": {
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "aurelia-router": "github:aurelia/router@0.12.0",
+      "aurelia-templating": "github:aurelia/templating@0.15.3"
+    },
+    "github:aurelia/templating@0.15.3": {
+      "aurelia-binding": "github:aurelia/binding@0.9.1",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
+      "aurelia-html-template-element": "github:aurelia/html-template-element@0.3.0",
+      "aurelia-loader": "github:aurelia/loader@0.9.0",
+      "aurelia-logging": "github:aurelia/logging@0.7.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+      "aurelia-path": "github:aurelia/path@0.9.0",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
+      "core-js": "npm:core-js@0.9.18"
+    },
+    "github:jspm/nodelibs-process@0.1.1": {
+      "process": "npm:process@0.10.1"
+    },
+    "github:twbs/bootstrap@3.3.5": {
+      "jquery": "github:components/jquery@2.1.4"
+    },
+    "npm:babel-runtime@5.8.24": {
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:core-js@0.9.18": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:core-js@1.1.4": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:font-awesome@4.4.0": {
+      "css": "github:systemjs/plugin-css@0.1.16"
+    }
+  }
+});

--- a/sample/index.html
+++ b/sample/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Aurelia</title>
+    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.4.0/css/font-awesome.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body aurelia-app="src/main">
+    <div class="splash">
+      <div class="message">Aurelia Navigation Skeleton</div>
+      <i class="fa fa-spinner fa-spin"></i>
+    </div>
+
+    <script src="jspm_packages/system.js"></script>
+    <script src="config.js"></script>
+    <script>
+      System.import('aurelia-bootstrapper');
+    </script>
+  </body>
+</html>

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,0 +1,22 @@
+{
+  "jspm": {
+    "dependencies": {
+      "aurelia-bootstrapper": "github:aurelia/bootstrapper@^0.17.0",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.10.1",
+      "aurelia-framework": "github:aurelia/framework@^0.16.0",
+      "aurelia-metadata": "github:aurelia/metadata@^0.8.0",
+      "aurelia-templating": "github:aurelia/templating@^0.15.3",
+      "font-awesome": "npm:font-awesome@^4.4.0",
+      "text": "github:systemjs/plugin-text@^0.0.2",
+      "twbs/bootstrap": "github:twbs/bootstrap@3.3.5"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.8.24",
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4"
+    }
+  },
+  "devDependencies": {
+    "jspm": "^0.16.6"
+  }
+}

--- a/sample/src/app.html
+++ b/sample/src/app.html
@@ -1,0 +1,3 @@
+<template>
+  <button click.trigger="submit()">Open Modal</button>
+</template>

--- a/sample/src/app.js
+++ b/sample/src/app.js
@@ -1,0 +1,19 @@
+import {inject} from 'aurelia-framework';
+import {DialogService} from 'aurelia-dialog';
+import {EditPerson} from './edit-person';
+
+@inject(DialogService)
+export class App {
+  constructor(dialogService) {
+    this.dialogService = dialogService;
+  }
+  submit(){
+    this.dialogService.open({ viewModel: EditPerson, model: 'Good or Bad?'}).then((result) => {
+      if (!result.wasCancelled) {
+        console.log('good');
+      } else {
+        console.log('bad');
+      }
+    });
+  }
+}

--- a/sample/src/edit-person.html
+++ b/sample/src/edit-person.html
@@ -1,0 +1,13 @@
+<template>
+  <dialog>
+    <dialog-body>
+      <h2>Edit first name</h2>
+      <input value.bind="person.firstName" />
+    </dialog-body>
+
+    <dialog-footer>
+      <button click.trigger="controller.cancel()">Cancel</button>
+      <button click.trigger="controller.ok(person)">Ok</button>
+    </dialog-footer>
+  </dialog>
+</template>

--- a/sample/src/edit-person.js
+++ b/sample/src/edit-person.js
@@ -1,0 +1,12 @@
+import {DialogController} from 'aurelia-dialog';
+
+export class EditPerson {
+  static inject = [DialogController];
+  person = { firstName: '' };
+  constructor(controller){
+    this.controller = controller;
+  }
+  activate(person){
+    this.person = person;
+  }
+}

--- a/sample/src/main.js
+++ b/sample/src/main.js
@@ -1,0 +1,10 @@
+import 'github:twbs/bootstrap@3.3.5';
+
+export function configure(aurelia) {
+  aurelia.use
+    .standardConfiguration()
+    .developmentLogging()
+    .plugin('aurelia-dialog');
+
+  aurelia.start().then(a => a.setRoot('src/app'));
+}

--- a/src/dialog-controller.js
+++ b/src/dialog-controller.js
@@ -28,19 +28,27 @@ export class DialogController {
   }
 
   close(ok, result) {
+    let returnResult = new DialogResult(!ok, result);
     return invokeLifecycle(this.viewModel, 'canDeactivate').then(canDeactivate => {
       if (canDeactivate) {
         return invokeLifecycle(this.viewModel, 'deactivate').then(() => {
           return this._renderer.hideDialog(this).then(() => {
             return this._renderer.destroyDialogHost(this).then(() => {
               this.behavior.unbind();
-              if (ok) {
-                this._resolve(result);
-              }
+              this._resolve(returnResult);
             });
           });
         });
       }
     });
+  }
+}
+
+class DialogResult {
+  wasCancelled = false;
+  output;
+  constructor(cancelled, result) {
+    this.wasCancelled = cancelled;
+    this.output = result;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,5 +13,6 @@ export function configure(config) {
     './attach-focus'
   );
 }
+
 export * from './dialog-service';
 export * from './dialog-controller';


### PR DESCRIPTION
Developer can now inspect the response and check the `wasCancelled`
property on the object returned.  It will return true or false depending
on whether it was cancelled or not.  The response will also now have an
`output` property that was previously simply the message.  Fixes #22.