### PR TITLE
Changed inner template in ai-dialog-footer.html to div and added some info to the Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,43 @@ To run the unit tests, first ensure that you have followed the steps above in or
 	```shell
 	npm install -g jspm
 	```
-3. Download the [SystemJS](https://github.com/systemjs/systemjs) module loader:
+
+3. You can now run `jspm` to install dependencies required for running the test suite:
+
+  ```shell
+  jspm install
+  ```
+
+4. Download the [SystemJS](https://github.com/systemjs/systemjs) module loader:
 
 	```shell
 	jspm dl-loader
 	```
 
-4. Ensure that you have Chrome installed. Karma runs the test suite in Chrome.
+5. Ensure that you have Chrome installed. Karma runs the test suite in Chrome.
 
-5. You can now run the tests with this command:
+6. You can now run the tests with this command:
 
 	```shell
 	karma start
 	```
+
+  ## Running The Sample
+
+To run the sample code using this plugin proceed with these additional steps:
+
+1. Go to the `sample` directory and install dependencies using `jspm`:
+
+  ```shell
+  cd sample
+  jspm install
+  ```
+2. Go back to the root of the project and use gulp to serve the sample project:
+
+  ```shell
+  cd ..
+  gulp watch
+  ```
 
 ## How to install this plugin?
 

--- a/dist/amd/ai-dialog-footer.html
+++ b/dist/amd/ai-dialog-footer.html
@@ -1,7 +1,7 @@
 <template>
   <content></content>
 
-  <template if.bind="buttons.length > 0">
+  <div if.bind="buttons.length > 0">
     <button type="button" class="btn btn-default" repeat.for="button of buttons" click.trigger="close(button)">${button}</button>
-  </template>
+  </div>
 </template>

--- a/dist/commonjs/ai-dialog-footer.html
+++ b/dist/commonjs/ai-dialog-footer.html
@@ -1,7 +1,7 @@
 <template>
   <content></content>
 
-  <template if.bind="buttons.length > 0">
+  <div if.bind="buttons.length > 0">
     <button type="button" class="btn btn-default" repeat.for="button of buttons" click.trigger="close(button)">${button}</button>
-  </template>
+  </div>
 </template>

--- a/dist/es6/ai-dialog-footer.html
+++ b/dist/es6/ai-dialog-footer.html
@@ -1,7 +1,7 @@
 <template>
   <content></content>
 
-  <template if.bind="buttons.length > 0">
+  <div if.bind="buttons.length > 0">
     <button type="button" class="btn btn-default" repeat.for="button of buttons" click.trigger="close(button)">${button}</button>
-  </template>
+  </div>
 </template>

--- a/dist/system/ai-dialog-footer.html
+++ b/dist/system/ai-dialog-footer.html
@@ -1,7 +1,7 @@
 <template>
   <content></content>
 
-  <template if.bind="buttons.length > 0">
+  <div if.bind="buttons.length > 0">
     <button type="button" class="btn btn-default" repeat.for="button of buttons" click.trigger="close(button)">${button}</button>
-  </template>
+  </div>
 </template>

--- a/src/ai-dialog-footer.html
+++ b/src/ai-dialog-footer.html
@@ -1,7 +1,7 @@
 <template>
   <content></content>
 
-  <template if.bind="buttons.length > 0">
+  <div if.bind="buttons.length > 0">
     <button type="button" class="btn btn-default" repeat.for="button of buttons" click.trigger="close(button)">${button}</button>
-  </template>
+  </div>
 </template>


### PR DESCRIPTION
Changing inner template element to div resolves bug in IE Edge (and problably earlier versions):

```
Unhandled promise rejection Error: Out of stack space
script block (123) (139,13)
   "Unhandled promise rejection"
   {
      [functions]: ,
      __proto__: { },
      description: "Out of stack space",
      message: "Out of stack space",
      name: "Error",
      number: -2146828260,
      stack: "Error: Out of stack space
   at compileNode (Unknown script code:1942:7)
   at compile (Unknown script code:1923:7)
   at compileElement (Unknown script code:2109:9)
   at compileNode (Unknown script code:1944:11)
   at compile (Unknown script code:1923:7)
   at compileElement (Unknown script code:2109:9)
   at compileNode (Unknown script code:1944:11)
   at compile (Unknown script code:1923:7)
   at compileElement (Unknown script code:2109:9)
   at compileNode (Unknown script code:1944:11)"
   }
```
Additionally added to Readme.md reminder that you should also run the `jspm install` before running tests in karma and instructions to run the sample from the sample directory.