### PR TITLE
disable pointer events on ai-dialog-container

### DIFF
--- a/src/styles/dialog.less
+++ b/src/styles/dialog.less
@@ -23,6 +23,9 @@ ai-dialog-container {
   overflow-x: hidden;
   overflow-y: auto;
 
+  // prevent pointer events to enable click event on ai-dialog-overlay
+  pointer-events: none;
+
   -webkit-overflow-scrolling: touch;
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951
@@ -54,6 +57,8 @@ ai-dialog {
   border-image-outset: initial;
   border-image-repeat: initial;
   background: white;
+
+  pointer-events: initial;
 
   > ai-dialog-header {
     display: block;


### PR DESCRIPTION
This disables pointer events on ai-dialog-container to enable the close click on ai-dialog-overlay.

without this css, the event listener here https://github.com/aurelia/dialog/blob/master/src/dialog-renderer.js#L66 never catches an event as the ai-dialog-container is on top of ai-dialog-overlay.

This solution only works for browsers supporting `pointer-events`: http://caniuse.com/#search=pointer-events