### PR TITLE
fix(dialog): use CSS auto margins instead of JS

### DIFF
--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -118,9 +118,6 @@ export class DialogRenderer {
     dialogController.centerDialog = () => {
       let child = modalContainer.children[0];
 
-      let vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-      child.style.marginLeft = Math.max((vw - child.offsetWidth) / 2, 0) + 'px';
-
       if (!settings.centerHorizontalOnly) {
         let vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
         // Left at least 30px from the top


### PR DESCRIPTION
The dialog did not auto-center on window resize. A CSS auto margin was used, but was being overwritten by `dialogController.centerDialog()`. Removing the lines of code setting an explicit margin-left inline style on the dialog container allows CSS to auto-center the modal even upon resize.

Fixes #55.