### PR TITLE
fix(dialog): allow response to click events

### DIFF
--- a/src/styles/dialog.less
+++ b/src/styles/dialog.less
@@ -6,6 +6,9 @@ ai-dialog-overlay {
   right: 0;
   opacity: 0;
 
+  // prevent pointer events to enable click event on ai-dialog-overlay
+  pointer-events: none;
+
   &.active {
     opacity: 1;
   }
@@ -23,9 +26,6 @@ ai-dialog-container {
   overflow-x: hidden;
   overflow-y: auto;
 
-  // prevent pointer events to enable click event on ai-dialog-overlay
-  pointer-events: none;
-
   -webkit-overflow-scrolling: touch;
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951
@@ -33,6 +33,12 @@ ai-dialog-container {
 
   &.active {
     opacity: 1;
+  }
+  
+  & > div {
+    // Prevent Chrome on Windows from adding a focus outline. For details, see
+    // https://github.com/twbs/bootstrap/pull/10951
+    outline: 0;
   }
 }
 

--- a/src/styles/dialog.less
+++ b/src/styles/dialog.less
@@ -25,17 +25,13 @@ ai-dialog-container {
   opacity: 0;
   overflow-x: hidden;
   overflow-y: auto;
-
   -webkit-overflow-scrolling: touch;
-  // Prevent Chrome on Windows from adding a focus outline. For details, see
-  // https://github.com/twbs/bootstrap/pull/10951
-  outline: 0;
 
   &.active {
     opacity: 1;
   }
   
-  & > div {
+  &, & > div {
     // Prevent Chrome on Windows from adding a focus outline. For details, see
     // https://github.com/twbs/bootstrap/pull/10951
     outline: 0;


### PR DESCRIPTION
fix: (issue #94) change dialog.less 

set the `pointer-events: none` to the overlay layer
prevent chrome on windows from adding a focus outline