### PR TITLE
Fix issue 82

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -81,15 +81,6 @@ gulp.task('build-system', ['build-html-system'], function () {
     .pipe(gulp.dest(paths.output + 'system'));
 });
 
-gulp.task('build-dts', function(){
-  return gulp.src(paths.root + paths.packageName + '.d.ts')
-    .pipe(gulp.dest(paths.output))
-    .pipe(gulp.dest(paths.output + 'es6'))
-    .pipe(gulp.dest(paths.output + 'commonjs'))
-    .pipe(gulp.dest(paths.output + 'amd'))
-    .pipe(gulp.dest(paths.output + 'system'));
-});
-
 gulp.task('build-html-commonjs', function () {
   return gulp.src(paths.html)
     .pipe(gulp.dest(paths.output + 'commonjs'));

--- a/src/dialog-controller.js
+++ b/src/dialog-controller.js
@@ -1,6 +1,7 @@
 import {invokeLifecycle} from './lifecycle';
 
 export class DialogController {
+  settings: any;
   constructor(renderer: DialogRenderer, settings: any, resolve: Function, reject: Function) {
     this._renderer = renderer;
     this.settings = settings;
@@ -8,11 +9,11 @@ export class DialogController {
     this._reject = reject;
   }
 
-  ok(result: DialogResult) {
+  ok(result: any) {
     this.close(true, result);
   }
 
-  cancel(result: DialogResult) {
+  cancel(result: any) {
     this.close(false, result);
   }
 
@@ -27,7 +28,7 @@ export class DialogController {
     });
   }
 
-  close(ok: boolean, result: DialogResult) {
+  close(ok: boolean, result: any) {
     let returnResult = new DialogResult(!ok, result);
     return invokeLifecycle(this.viewModel, 'canDeactivate').then(canDeactivate => {
       if (canDeactivate) {
@@ -45,9 +46,9 @@ export class DialogController {
 }
 
 class DialogResult {
-  wasCancelled = false;
-  output;
-  constructor(cancelled, result) {
+  wasCancelled: boolean = false;
+  output: any;
+  constructor(cancelled: boolean, result: any) {
     this.wasCancelled = cancelled;
     this.output = result;
   }


### PR DESCRIPTION
- f2a50056c4453b8717bc072b1e08488bab730880 : solves issue #82 and also exposes the `settings` attribute of `DialogController`
- 2f2ec7f8d7706e8fb8cd8ddbcc9443bc95bbeceb : minor change to `build.js`
- 017b5bf4555ca07e0fca1f9186728a78d14e4f4d : The `d.ts`  file is generated by a `gulp build`. This commit includes all the changes triggered by the `gulp build` command.