### PR TITLE
Attach focus value

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ The modal exposes an `attach-focus` custom attribute that allows focusing in on 
     </ai-dialog>
   </template>
   ```
+  
+You can also bind the value of the attach-focus attribute if you want to alter which element will be focused based on a view model property.
+
+  ```html
+  <input attach-focus.bind="isNewPerson" value.bind="person.email" />
+  <input attach-focus.bind="!isNewPerson" value.bind="person.firstName" />
+  ```
 
 ###Global Settings
 You can specify global settings as well for all dialogs to use when installing the plugin via the configure method.

--- a/src/attach-focus.js
+++ b/src/attach-focus.js
@@ -4,12 +4,20 @@ import {customAttribute} from 'aurelia-templating';
 export class AttachFocus {
   static inject = [Element];
 
+  value = true;
+
   constructor(element) {
     this.element = element;
   }
 
   attached() {
-    this.element.focus();
+    if (this.value && this.value !== 'false') {
+      this.element.focus();
+    }
+  }
+  
+  valueChanged(newValue) {
+    this.value = newValue;
   }
 }
 

--- a/test/unit/attach-focus.spec.js
+++ b/test/unit/attach-focus.spec.js
@@ -23,12 +23,32 @@ describe('modal gets focused when attached', () => {
     jasmine.clock().uninstall();
   });
 
-  it('should call the focus method when attached', done => {
+  it('should call the focus method when attached without value', done => {
     attachFocus = templatingEngine.createViewModelForUnitTest(AttachFocus);
     spyOn(element, 'focus').and.callThrough();
     attachFocus.attached();
     jasmine.clock().tick(1);
     expect(element.focus).toHaveBeenCalled();
+    done();
+  });
+  
+  it('should call the focus method when attached to true value', done => {
+    attachFocus = templatingEngine.createViewModelForUnitTest(AttachFocus);
+    attachFocus.value = true;
+    spyOn(element, 'focus').and.callThrough();
+    attachFocus.attached();
+    jasmine.clock().tick(1);
+    expect(element.focus).toHaveBeenCalled();
+    done();
+  });
+  
+  it('should not call the focus method when attached to false value', done => {
+    attachFocus = templatingEngine.createViewModelForUnitTest(AttachFocus);
+    attachFocus.value = false;
+    spyOn(element, 'focus').and.callThrough();
+    attachFocus.attached();
+    jasmine.clock().tick(1);
+    expect(element.focus).not.toHaveBeenCalled();
     done();
   });
 });


### PR DESCRIPTION
Use the value of the attach-focus attribute to decide if the element is to be focused on attach. This allows using binding to alter the focused element.