### PR TITLE
feat(position): allow to pass in callback to do setup on elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The modal exposes an `attach-focus` custom attribute that allows focusing in on 
     </ai-dialog>
   </template>
   ```
-  
+
 You can also bind the value of the attach-focus attribute if you want to alter which element will be focused based on a view model property.
 
   ```html
@@ -257,6 +257,7 @@ export function configure(aurelia) {
 The settings available for the dialog are set on the dialog controller on a per-dialog basis.
 - `lock` makes the dialog modal, and removes the close button from the top-right hand corner. (defaults to true)
 - `centerHorizontalOnly` means that the dialog will be centered horizontally, and the vertical alignment is left up to you. (defaults to false)
+- `position` a callback that is called right before showing the modal with the signature: `(modalContainer: Element, modalOverlay: Element) => void`. This allows you to setup special classes, play with the position, etc... If specified, `centerHorizontalOnly` is ignored. (optional)
 
 ```javascript
 export class Prompt {

--- a/config.js
+++ b/config.js
@@ -16,10 +16,13 @@ System.config({
 
   map: {
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
+    "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.0",
+    "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0-beta.1.1.3",
     "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
     "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.2",
     "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.0",
+    "aurelia-templating-binding": "npm:aurelia-templating-binding@1.0.0-beta.1.1.2",
     "babel": "npm:babel-core@5.8.35",
     "babel-runtime": "npm:babel-runtime@5.8.35",
     "core-js": "npm:core-js@2.0.3",
@@ -38,17 +41,21 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:aurelia-binding@1.0.0-beta.1.1.0": {
+    "npm:aurelia-binding@1.0.0-beta.1.2.1": {
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.0",
-      "core-js": "npm:core-js@2.0.3"
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.0"
     },
     "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2": {
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
       "core-js": "npm:core-js@2.0.3"
+    },
+    "npm:aurelia-loader-default@1.0.0-beta.1.1.3": {
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
     },
     "npm:aurelia-loader@1.0.0-beta.1.1.0": {
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
@@ -65,8 +72,13 @@ System.config({
     "npm:aurelia-task-queue@1.0.0-beta.1.1.0": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
     },
+    "npm:aurelia-templating-binding@1.0.0-beta.1.1.2": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.0"
+    },
     "npm:aurelia-templating@1.0.0-beta.1.1.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.1.0",
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
       "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.0",
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,9 @@ module.exports = function(config) {
 
 
     // list of files / patterns to load in the browser
-    files: [],
+    files: [
+      'test/**/*.html'
+    ],
 
 
     // list of files to exclude

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
       "aurelia-templating": "^1.0.0-beta.1.1.0"
     },
     "devDependencies": {
+      "aurelia-loader": "^1.0.0-beta.1.1.0",
+      "aurelia-loader-default": "^1.0.0-beta.1.1.1",
       "aurelia-pal-browser": "^1.0.0-beta.1.1.2",
+      "aurelia-templating-binding": "^1.0.0-beta.1.1.1",
       "babel": "babel-core@^5.8.24",
       "babel-runtime": "^5.8.24",
       "core-js": "^2.0.3"

--- a/sample/src/app.html
+++ b/sample/src/app.html
@@ -1,3 +1,4 @@
 <template>
   <button click.trigger="submit()">Open Modal</button>
+  <button style="position: absolute; top: 100px; left: 50px;" click.trigger="positionManually($event)">Open Next To Me</button>
 </template>

--- a/sample/src/app.js
+++ b/sample/src/app.js
@@ -7,8 +7,35 @@ export class App {
   constructor(dialogService) {
     this.dialogService = dialogService;
   }
+
   submit(){
     this.dialogService.open({ viewModel: EditPerson, model: { firstName: 'Owen' }}).then((result) => {
+      if (!result.wasCancelled) {
+        console.log('good');
+        console.log(result.output);
+      } else {
+        console.log('bad');
+      }
+    });
+  }
+
+  positionManually(e) {
+    const settings = {
+      viewModel: EditPerson,
+      model: { firstName: 'Owen' },
+      position: (modalContainer) => {
+        const { offsetWidth, offsetLeft, offsetTop } = e.target;
+
+        const dialog = modalContainer.querySelector('ai-dialog');
+        dialog.style.top = offsetTop + 'px';
+        dialog.style.left = offsetLeft + offsetWidth + 'px';
+
+        // quick override on the style
+        dialog.style.margin = '0';
+      }
+    };
+
+    this.dialogService.open(settings).then((result) => {
       if (!result.wasCancelled) {
         console.log('good');
         console.log(result.output);

--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -24,6 +24,13 @@ function getNextZIndex() {
   return ++currentZIndex;
 }
 
+function centerDialog(modalContainer) {
+  const child = modalContainer.children[0];
+  const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+
+  child.style.marginTop = Math.max((vh - child.offsetHeight) / 2, 30) + 'px';
+}
+
 export let globalSettings = {
   lock: true,
   centerHorizontalOnly: false,
@@ -64,7 +71,13 @@ export class DialogRenderer {
       this.dialogControllers.push(dialogController);
 
       dialogController.slot.attached();
-      dialogController.centerDialog();
+      if (typeof settings.position === 'function') {
+        settings.position(modalContainer, modalOverlay);
+      } else {
+        if (!settings.centerHorizontalOnly) {
+          centerDialog(modalContainer);
+        }
+      }
 
       modalOverlay.onclick = () => {
         if (!settings.lock) {
@@ -116,16 +129,6 @@ export class DialogRenderer {
       document.body.removeChild(modalContainer);
       dialogController.slot.detached();
       return Promise.resolve();
-    };
-
-    dialogController.centerDialog = () => {
-      let child = modalContainer.children[0];
-
-      if (!settings.centerHorizontalOnly) {
-        let vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-        // Left at least 30px from the top
-        child.style.marginTop = Math.max((vh - child.offsetHeight) / 2, 30) + 'px';
-      }
     };
 
     return Promise.resolve();

--- a/test/fixtures/test-element.html
+++ b/test/fixtures/test-element.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/test/unit/attach-focus.spec.js
+++ b/test/unit/attach-focus.spec.js
@@ -23,32 +23,29 @@ describe('modal gets focused when attached', () => {
     jasmine.clock().uninstall();
   });
 
-  it('should call the focus method when attached without value', done => {
+  it('should call the focus method when attached without value', () => {
     attachFocus = templatingEngine.createViewModelForUnitTest(AttachFocus);
     spyOn(element, 'focus').and.callThrough();
     attachFocus.attached();
     jasmine.clock().tick(1);
     expect(element.focus).toHaveBeenCalled();
-    done();
   });
-  
-  it('should call the focus method when attached to true value', done => {
+
+  it('should call the focus method when attached to true value', () => {
     attachFocus = templatingEngine.createViewModelForUnitTest(AttachFocus);
     attachFocus.value = true;
     spyOn(element, 'focus').and.callThrough();
     attachFocus.attached();
     jasmine.clock().tick(1);
     expect(element.focus).toHaveBeenCalled();
-    done();
   });
-  
-  it('should not call the focus method when attached to false value', done => {
+
+  it('should not call the focus method when attached to false value', () => {
     attachFocus = templatingEngine.createViewModelForUnitTest(AttachFocus);
     attachFocus.value = false;
     spyOn(element, 'focus').and.callThrough();
     attachFocus.attached();
     jasmine.clock().tick(1);
     expect(element.focus).not.toHaveBeenCalled();
-    done();
   });
 });

--- a/test/unit/dialog-controller.spec.js
+++ b/test/unit/dialog-controller.spec.js
@@ -11,15 +11,18 @@ describe('the Dialog Controller', () => {
     settings = { name: 'Test' };
     dialogController = new DialogController(renderer, settings);
   });
+
   it('should be created with a settings property', () => {
     expect(dialogController.settings).toEqual(settings);
   });
+
   it('should call close with success when ok method called', () => {
     let calledValue = 'Worked';
     spyOn(dialogController, 'close');
     dialogController.ok(calledValue);
     expect(dialogController.close).toHaveBeenCalledWith(true, calledValue);
   });
+
   it('should call close without success when cancel method called', () => {
     let calledValue = 'Didnt work';
     spyOn(dialogController, 'close');

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -1,9 +1,7 @@
 import {DialogRenderer} from '../../src/dialog-renderer';
 import {DialogController} from '../../src/dialog-controller';
-import {Container} from 'aurelia-dependency-injection';
 import {configure} from '../../src/index';
 
-let element = document.createElement('div');
 let defaultSettings = {
   lock: true,
   centerHorizontalOnly: false,
@@ -24,35 +22,21 @@ let frameworkConfig = {
 };
 
 describe('the Dialog Renderer', () => {
-  let renderer,
-    container,
-    controller;
-
-  beforeEach(() => {
-    container = new Container().makeGlobal();
-    container.registerInstance(Element, element);
-    jasmine.clock().install();
-  });
-
-  afterEach(() => {
-    jasmine.clock().uninstall();
-  });
-
-  it('uses the default settings', done => {
-    renderer = new DialogRenderer();
+  it('uses the default settings', () => {
+    let renderer = new DialogRenderer();
     expect(renderer.defaultSettings).toEqual(defaultSettings);
-    done();
   });
 
-  it('allows overriding the default settings', done => {
+  it('allows overriding the default settings', () => {
     let callback = (globalSettings) => {
       Object.assign(globalSettings, newSettings);
     }
+
     configure(frameworkConfig, callback);
-    renderer = new DialogRenderer();
+    let renderer = new DialogRenderer();
     let dialogController = new DialogController(renderer);
+
     expect(renderer.defaultSettings).toEqual(newSettings);
-    done();
   });
 });
 

--- a/test/unit/dialog-service.spec.js
+++ b/test/unit/dialog-service.spec.js
@@ -1,9 +1,12 @@
 import {DialogService} from '../../src/dialog-service';
 import {Container} from 'aurelia-dependency-injection';
-import {CompositionEngine} from 'aurelia-templating';
+import {CompositionEngine, BindingLanguage} from 'aurelia-templating';
 import {DialogRenderer} from '../../src/dialog-renderer';
 import {TestElement} from '../fixtures/test-element';
-import {TestModel} from '../fixtures/test-model';
+import {initialize} from 'aurelia-pal-browser';
+import {Loader} from 'aurelia-loader';
+import {DefaultLoader} from 'aurelia-loader-default';
+import {TemplatingBindingLanguage} from 'aurelia-templating-binding';
 
 describe('the Dialog Service', () => {
   let dialogService,
@@ -12,18 +15,38 @@ describe('the Dialog Service', () => {
     renderer;
 
   beforeEach(() => {
+    initialize();
+
     container = new Container();
-    compEng = new CompositionEngine();
+    container.registerSingleton(Loader, DefaultLoader);
+    container.registerSingleton(BindingLanguage, TemplatingBindingLanguage);
+    container.registerAlias(BindingLanguage, TemplatingBindingLanguage);
+
+    compEng = container.get(CompositionEngine);
     renderer = new DialogRenderer();
     dialogService = new DialogService(container, compEng, renderer);
   });
-  it('open with a model settings applied', () => {
-    let model = new TestModel();
-    let settings = { viewModel: TestElement, model: model };
-    let result = dialogService.open(settings);
-    result.then(resp => {
-      spyOn(resp.renderer, 'showDialog');
-      expect(resp.renderer.showDialog).toHaveBeenCalled();
+
+  it('open with a model settings applied', (done) => {
+    const settings = { viewModel: TestElement };
+
+    spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
+      done();
     });
-   });
+
+    dialogService.open(settings);
+  });
+
+  it('calls position if specified', (done) => {
+    const settings = {
+      viewModel: TestElement,
+      position: (modalContainer, modalOverlay) => {
+        expect(modalContainer.tagName).toBe('AI-DIALOG-CONTAINER');
+        expect(modalOverlay.tagName).toBe('AI-DIALOG-OVERLAY');
+        done();
+      }
+    };
+
+    dialogService.open(settings);
+  });
 });

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -1,15 +1,10 @@
 import {configure} from '../../src/index';
 
 describe('testing aurelia configure routine', () => {
-
   var frameworkConfig = {
-    globalResources: () => {
-
-    },
+    globalResources: () => { },
     container: {
-      registerInstance: (type, callback) => {
-
-      },
+      registerInstance: (type, callback) => { },
       get: (type) => { return new type(); }
     }
   };


### PR DESCRIPTION
I didn't create an issue for this feature, since it is a pretty small change.

The motivation for this feature is to allow for the dialog plugin to also render 'pop-up' like dialogs.

![image](https://cloud.githubusercontent.com/assets/551020/13453579/da3aa5c6-e016-11e5-85a6-61e23ed3ee8e.png)

The way I implemented this is by allowing you to pass in a `position` callback that the renderer uses to pass through the container and overlay. This callback is optional.

I believe this will allow issues like #84 to go away, as the caller can just implement this.

I have updated the sample to demonstrate what you can do with this.

I also updated the service tests. I'm not sure if that is something you want to test, but the only way to get through that promise chain in service.open is to include a few dev dependencies and setup the container.

Let me know your thoughts!