### PR TITLE
fix(DialogController): fix type definitions for dialog result parameters

### DIFF
--- a/dist/aurelia-dialog.d.ts
+++ b/dist/aurelia-dialog.d.ts
@@ -32,10 +32,10 @@ declare module 'aurelia-dialog' {
   }
   export class DialogController {
     constructor(renderer: DialogRenderer, settings: any, resolve: Function, reject: Function);
-    ok(result: DialogResult): any;
-    cancel(result: DialogResult): any;
+    ok(result: any): any;
+    cancel(result: any): any;
     error(message: any): any;
-    close(ok: boolean, result: DialogResult): any;
+    close(ok: boolean, result: any): any;
   }
   class DialogResult {
     wasCancelled: any;


### PR DESCRIPTION
Modify the aurelia-dialog type definitions file so that it accepts an any parameter instead
of a DialogResult parameter, to correspond with recent changes to DialogController

Fixes issue #110