### PR TITLE
feat(dialog): track controllers in service

### DIFF
--- a/test/unit/dialog-service.spec.js
+++ b/test/unit/dialog-service.spec.js
@@ -49,4 +49,32 @@ describe('the Dialog Service', () => {
 
     dialogService.open(settings);
   });
+
+  it('reports no active dialog if no dialog is open', () => {
+    const settings = { viewModel: TestElement };
+
+    spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
+      dialogController.cancel();
+      done();
+    });
+
+    expect(dialogService.hasActiveDialog).toBe(false);
+
+    dialogService.open(settings)
+      .then(() => {
+        expect(dialogService.hasActiveDialog).toBe(false);
+        done();
+      });
+  });
+
+  it('reports an active dialog if a dialog is open', (done) => {
+    const settings = { viewModel: TestElement };
+
+    spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
+      expect(dialogService.hasActiveDialog).toBe(true);
+      done();
+    });
+
+    dialogService.open(settings);
+  });
 });


### PR DESCRIPTION
Dialog controllers were not tracked or destroyed by the service. Thus, there was no way to determine whether a dialog was active. We add a controllers array to the service to track all active dialog controllers, adding them upon dialog initialization and removing their reference when the `open` promise is resolved. This does not remove the collection from the renderer - it merely separates the concerns.

Fixes #121.