### PR TITLE
refactor(dialog): refactor renderer and service

### DIFF
--- a/sample/config.js
+++ b/sample/config.js
@@ -22,7 +22,8 @@ System.config({
         "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.3",
         "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.1.2",
         "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.4",
-        "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.1"
+        "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.1",
+        "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
       }
     }
   },
@@ -33,6 +34,7 @@ System.config({
     "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.2.0",
     "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
     "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.0",
+    "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.6",

--- a/src/dialog-controller.js
+++ b/src/dialog-controller.js
@@ -1,5 +1,6 @@
 import {invokeLifecycle} from './lifecycle';
 
+
 /**
  * A controller object for a Dialog instance.
  * @constructor
@@ -8,7 +9,7 @@ export class DialogController {
   settings: any;
   constructor(renderer: DialogRenderer, settings: any, resolve: Function, reject: Function) {
     this._renderer = renderer;
-    this.settings = settings;
+    this.settings = Object.assign({}, this._renderer.defaultSettings, settings);
     this._resolve = resolve;
     this._reject = reject;
   }

--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -10,12 +10,11 @@ import {invokeLifecycle} from './lifecycle';
  * @constructor
  */
 export class DialogService {
-  static inject = [Container, CompositionEngine, Renderer];
+  static inject = [Container, CompositionEngine];
 
-  constructor(container: Container, compositionEngine, renderer) {
+  constructor(container: Container, compositionEngine) {
     this.container = container;
     this.compositionEngine = compositionEngine;
-    this.renderer = renderer;
     this.controllers = [];
     this.hasActiveDialog = false;
   }
@@ -26,38 +25,35 @@ export class DialogService {
    * @return Promise A promise that settles when the dialog is closed.
    */
   open(settings?: Object) {
-    let _settings = Object.assign({}, this.renderer.defaultSettings, settings);
     let dialogController;
 
     let promise = new Promise((resolve, reject) => {
       let childContainer = this.container.createChild();
-      dialogController = new DialogController(this.renderer, _settings, resolve, reject);
-      let instruction = {
-        viewModel: _settings.viewModel,
-        container: this.container,
-        childContainer: childContainer,
-        model: _settings.model
-      };
-
+      dialogController = new DialogController(childContainer.get(Renderer), settings, resolve, reject);
       childContainer.registerInstance(DialogController, dialogController);
 
-      return this._getViewModel(instruction).then(returnedInstruction => {
-        dialogController.viewModel = returnedInstruction.viewModel;
+      let instruction = {
+        container: this.container,
+        childContainer: childContainer,
+        model: dialogController.settings.model,
+        viewModel: dialogController.settings.viewModel,
+        viewSlot: new ViewSlot(dialogController._renderer.getDialogContainer(), true)
+      };
 
-        return invokeLifecycle(returnedInstruction.viewModel, 'canActivate', _settings.model).then(canActivate => {
+      return _getViewModel(instruction, this.compositionEngine).then(returnedInstruction => {
+        dialogController.viewModel = returnedInstruction.viewModel;
+        dialogController.slot = returnedInstruction.viewSlot;
+
+        return invokeLifecycle(dialogController.viewModel, 'canActivate', dialogController.settings.model).then(canActivate => {
           if (canActivate) {
             this.controllers.push(dialogController);
             this.hasActiveDialog = !!this.controllers.length;
 
-            return this.compositionEngine.createController(returnedInstruction).then(controller => {
+            return this.compositionEngine.compose(returnedInstruction).then(controller => {
               dialogController.controller = controller;
               dialogController.view = controller.view;
-              controller.automate();
 
-              dialogController.slot = new ViewSlot(this.renderer.getDialogContainer(), true);
-              dialogController.slot.add(dialogController.view);
-
-              return this.renderer.showDialog(dialogController);
+              return dialogController._renderer.showDialog(dialogController);
             });
           }
         });
@@ -74,16 +70,16 @@ export class DialogService {
       return result;
     });
   }
+}
 
-  _getViewModel(instruction) {
-    if (typeof instruction.viewModel === 'function') {
-      instruction.viewModel = Origin.get(instruction.viewModel).moduleId;
-    }
-
-    if (typeof instruction.viewModel === 'string') {
-      return this.compositionEngine.ensureViewModel(instruction);
-    }
-
-    return Promise.resolve(instruction);
+function _getViewModel(instruction, compositionEngine) {
+  if (typeof instruction.viewModel === 'function') {
+    instruction.viewModel = Origin.get(instruction.viewModel).moduleId;
   }
+
+  if (typeof instruction.viewModel === 'string') {
+    return compositionEngine.ensureViewModel(instruction);
+  }
+
+  return Promise.resolve(instruction);
 }

--- a/test/unit/attach-focus.spec.js
+++ b/test/unit/attach-focus.spec.js
@@ -4,6 +4,8 @@ import {TemplatingEngine} from 'aurelia-templating';
 import {initialize} from 'aurelia-pal-browser';
 import {DOM} from 'aurelia-pal';
 
+initialize();
+
 let element = document.createElement('div');
 
 describe('modal gets focused when attached', () => {

--- a/test/unit/dialog-configuration.spec.js
+++ b/test/unit/dialog-configuration.spec.js
@@ -1,7 +1,10 @@
 import {DialogConfiguration} from '../../src/dialog-configuration';
 import {dialogOptions} from '../../src/dialog-options';
 import {DialogRenderer} from '../../src/renderers/dialog-renderer';
+import {initialize} from 'aurelia-pal-browser';
 import {Renderer} from '../../src/renderers/renderer';
+
+initialize();
 
 let defaultDialogOptions = Object.assign({}, dialogOptions);
 
@@ -13,6 +16,8 @@ let aurelia = {
 describe('DialogConfiguration', () => {
   let configuration;
   beforeEach(() => {
+    initialize();
+
     configuration = new DialogConfiguration(aurelia);
 
     Object.keys(dialogOptions).forEach((key) => {

--- a/test/unit/dialog-controller.spec.js
+++ b/test/unit/dialog-controller.spec.js
@@ -1,12 +1,18 @@
 import {DialogController} from '../../src/dialog-controller';
 import {Container} from 'aurelia-dependency-injection';
+import {initialize} from 'aurelia-pal-browser';
+
+initialize();
 
 describe('the Dialog Controller', () => {
   let dialogController;
-  let renderer;
+  let renderer = {
+    defaultSettings: {}
+  };
   let settings;
 
   beforeEach(() => {
+    initialize();
     new Container().makeGlobal();
     settings = { name: 'Test' };
     dialogController = new DialogController(renderer, settings);

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -1,6 +1,11 @@
+import {DialogController} from '../../src/dialog-controller';
 import {DialogRenderer} from '../../src/renderers/dialog-renderer';
 import {dialogOptions} from '../../src/dialog-options';
 import {configure} from '../../src/aurelia-dialog';
+import {initialize} from 'aurelia-pal-browser';
+import {TestElement} from '../fixtures/test-element';
+
+initialize();
 
 let defaultSettings = {
   lock: true,
@@ -22,9 +27,33 @@ let frameworkConfig = {
 };
 
 describe('the Dialog Renderer', () => {
+  beforeEach(() => {
+    initialize();
+  });
+
   it('uses the default settings', () => {
     let renderer = new DialogRenderer();
     expect(renderer.defaultSettings).toEqual(defaultSettings);
+  });
+
+  it('calls position if specified', (done) => {
+    const settings = {
+      viewModel: TestElement,
+      position: (modalContainer, modalOverlay) => {
+        expect(modalContainer.tagName).toBe('AI-DIALOG-CONTAINER');
+        expect(modalOverlay.tagName).toBe('AI-DIALOG-OVERLAY');
+        done();
+      }
+    };
+
+    let renderer = new DialogRenderer();
+    let controller = new DialogController(renderer, settings, Function.prototype, Function.prototype);
+    controller.slot = {
+      attached: Function.prototype,
+      anchor: document.createElement('ai-dialog-container')
+    };
+
+    renderer.showDialog(controller);
   });
 
   it('allows overriding the default settings', () => {

--- a/test/unit/dialog-service.spec.js
+++ b/test/unit/dialog-service.spec.js
@@ -1,12 +1,14 @@
 import {DialogService} from '../../src/dialog-service';
+import {Renderer} from '../../src/renderers/renderer';
 import {Container} from 'aurelia-dependency-injection';
 import {CompositionEngine, BindingLanguage} from 'aurelia-templating';
-import {DialogRenderer} from '../../src/renderers/dialog-renderer';
 import {TestElement} from '../fixtures/test-element';
 import {initialize} from 'aurelia-pal-browser';
 import {Loader} from 'aurelia-loader';
 import {DefaultLoader} from 'aurelia-loader-default';
 import {TemplatingBindingLanguage} from 'aurelia-templating-binding';
+
+initialize();
 
 describe('the Dialog Service', () => {
   let dialogService;
@@ -17,13 +19,22 @@ describe('the Dialog Service', () => {
   beforeEach(() => {
     initialize();
 
+    renderer = {
+      showDialog: function() {
+        return Promise.resolve();
+      },
+      getDialogContainer: function() {
+        return document.createElement('div');
+      }
+    };
+
     container = new Container();
     container.registerSingleton(Loader, DefaultLoader);
     container.registerSingleton(BindingLanguage, TemplatingBindingLanguage);
     container.registerAlias(BindingLanguage, TemplatingBindingLanguage);
+    container.registerInstance(Renderer, renderer);
 
     compEng = container.get(CompositionEngine);
-    renderer = new DialogRenderer();
     dialogService = new DialogService(container, compEng, renderer);
   });
 
@@ -33,19 +44,6 @@ describe('the Dialog Service', () => {
     spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
       done();
     });
-
-    dialogService.open(settings);
-  });
-
-  it('calls position if specified', (done) => {
-    const settings = {
-      viewModel: TestElement,
-      position: (modalContainer, modalOverlay) => {
-        expect(modalContainer.tagName).toBe('AI-DIALOG-CONTAINER');
-        expect(modalOverlay.tagName).toBe('AI-DIALOG-OVERLAY');
-        done();
-      }
-    };
 
     dialogService.open(settings);
   });

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -1,4 +1,7 @@
 import {configure} from '../../src/aurelia-dialog';
+import {initialize} from 'aurelia-pal-browser';
+
+initialize();
 
 describe('testing aurelia configure routine', () => {
   let frameworkConfig = {


### PR DESCRIPTION
Change dialog renderer to use PAL. Alter DOM ordering of dialog elements and remove z-index ordering. Alter default renderer to be transient

Fixes #67. Fixes #70.