### PR TITLE
Fix show & close for fast code close of dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,16 @@ jspm install aurelia-dialog
   ```
 3. Create (if you haven't already) a file `main.js` in your `src` folder with following content:
 
-```javascript
-  export function configure(aurelia) {
-    aurelia.use
-      .standardConfiguration()
-      .developmentLogging()
-      .plugin('aurelia-dialog');
+	```javascript
+	  export function configure(aurelia) {
+	    aurelia.use
+	      .standardConfiguration()
+	      .developmentLogging()
+	      .plugin('aurelia-dialog');
 
-    aurelia.start().then(a => a.setRoot());
-  }
-```
+	    aurelia.start().then(a => a.setRoot());
+	  }
+	```
 
 ## Using the plugin
 
@@ -212,6 +212,62 @@ There are a few ways you can take advantage of the Aurelia dialog.
   </template>
   ```
 
+### Force close from code - Progress dialogs
+
+Maybe you want to show a dialog during a long running process e.g. a progress dialog while data is retrieved. The controller's close method can be accessed via your model -
+
+```javascript
+activate(progressOptions) {
+	progressOptions.closeDialog = () => {
+		that.controller.close(true, null)
+			.catch((error) => {
+				//dont care if close failed
+				console.log("Error: controller.close threw error: " + error);
+			});
+	}
+}
+```
+
+Then you app's view-model can force the dialog to close -
+
+```javascript
+getDataWithProgressDialog(getDataPromise) {
+	let progressOptions = {
+		waitMessage: "Fetching data",
+	};
+	this.dialogService.open({
+		viewModel: Progress,
+		model: progressOptions
+	});
+
+	getDataPromise.then(() => {
+		progressOptions.closeDialog();
+	});
+}
+```
+
+However your getDataPromise could finish before the dialog show has completed (the show has a 200 ms transition to finish after it has got its resources). Some data fetch promises can resolve very quickly if the data is cached. You should ensure the show has completed by chaining from the showDialogPromise added to the model by the dialog service.
+
+```javascript
+getDataWithProgressDialog(getDataPromise) {
+	let progressOptions = {
+		waitMessage: "Fetching data"
+	};
+
+	this.dialogService.open({
+		viewModel: Progress,
+		model: progressOptions
+	});
+
+  getDataPromise.then(() => {
+		return progressOptions.showDialogPromise
+	}).then(() => {
+		progressOptions.closeDialog();
+	});
+}
+```
+
+
 ### attach-focus custom attribute
 
 The modal exposes an `attach-focus` custom attribute that allows focusing in on an element in the modal when it is loaded.  You can use this to focus a button, input, etc...  Example usage -
@@ -234,7 +290,7 @@ You can also bind the value of the attach-focus attribute if you want to alter w
   <input attach-focus.bind="!isNewPerson" value.bind="person.firstName" />
   ```
 
-###Global Settings
+### Global Settings
 You can specify global settings as well for all dialogs to use when installing the plugin via the configure method. If providing a custom configuration, you *must* call the `useDefaults()` method to apply the base configuration.
 
 ```javascript
@@ -255,11 +311,12 @@ export function configure(aurelia) {
 
 > Note: The startingZIndex will only be assignable during initial configuration.  This is because we stack everything on that Z-index after bootstrapping the modal.
 
-###Settings
+### Settings
 The settings available for the dialog are set on the dialog controller on a per-dialog basis.
 - `lock` makes the dialog modal, and removes the close button from the top-right hand corner. (defaults to true)
 - `centerHorizontalOnly` means that the dialog will be centered horizontally, and the vertical alignment is left up to you. (defaults to false)
 - `position` a callback that is called right before showing the modal with the signature: `(modalContainer: Element, modalOverlay: Element) => void`. This allows you to setup special classes, play with the position, etc... If specified, `centerHorizontalOnly` is ignored. (optional)
+- `showDialogTimeout` sets the timeout before the show dialog transitionEnd event is forced, as it is sometimes lost. It should be just greater than dialog.css ai-dialog-container transition duration, which defaults to 200. (defaults to 250)
 
 ```javascript
 export class Prompt {

--- a/sample/index.html
+++ b/sample/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Aurelia</title>
-    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body aurelia-app="src/main">

--- a/sample/src/app.html
+++ b/sample/src/app.html
@@ -1,4 +1,12 @@
 <template>
   <button click.trigger="submit()">Open Modal</button>
-  <button style="position: absolute; top: 100px; left: 50px;" click.trigger="positionManually($event)">Open Next To Me</button>
+  <button style="position: absolute; top: 200px; left: 50px;" click.trigger="positionManually($event)">Open Next To Me</button>
+
+  <h3>Progress dialogs</h3>
+
+  <button click.trigger="slowProgress($event)">Slow Progress</button>
+  <button click.trigger="faultyProgress($event)">Faulty Progress</button>
+  <button click.trigger="fastProgress($event)">Fast Progress</button>
+  <button click.trigger="fastestProgress($event)">Fastest Progress</button>
+
 </template>

--- a/sample/src/app.js
+++ b/sample/src/app.js
@@ -1,6 +1,7 @@
 import {inject} from 'aurelia-framework';
 import {DialogService} from 'aurelia-dialog';
 import {EditPerson} from './edit-person';
+import {Progress} from './progress';
 
 @inject(DialogService)
 export class App {
@@ -43,5 +44,96 @@ export class App {
         console.log('bad');
       }
     });
+  }
+
+
+
+  slowProgress(e) {
+    let progressOptions = {
+      waitMessage: "Fetching slow data"
+    };
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    let process = {
+      progressInterval: 500,
+      progressPercentIncrease: 20
+    }
+    setTimeout(this.incrementProgress, process.progressInterval, this, process, progressOptions);
+  }
+
+  faultyProgress(e) {
+    alert('Faulty as it closes synchronously instead of after the open promise.'
+      + ' If pressed first, the close will fail and the console will log the caught promise error "TypeError: dialogController.hideDialog is not a function".'
+      + ' If another button is pressed first, it will silently fail to destroy the dialog, leaving ai-dialog-overlay hidden but still blocking.')
+
+    let progressOptions = {
+      waitMessage: "Fetching fast data",
+    };
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    let process = {
+      progressInterval: 0,            //faster than transitionEnd event, so open is not completed.
+      progressPercentIncrease: 100
+    }
+    setTimeout(this.incrementProgress, process.progressInterval, this, process, progressOptions);
+  }
+
+  fastProgress(e) {
+    let progressOptions = {
+      waitMessage: "Fetching fast data",
+    };
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    let process = {
+      progressInterval: 0,
+      progressPercentIncrease: 100,
+      terminateProgressDailog: () => {
+        //have to let renderer completely build controller, so
+        progressOptions.showDialogPromise.then(() => {
+          progressOptions.closeDialog();
+        });
+      }
+    }
+
+    setTimeout(this.incrementProgress, process.progressInterval, this, process, progressOptions);
+  }
+
+  fastestProgress(e) {
+    let progressOptions = {
+      waitMessage: "Get data now"
+    };
+
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    //no timeout progress, straight to close
+    progressOptions.showDialogPromise.then(() => {
+      progressOptions.closeDialog();
+    });
+  }
+
+
+  incrementProgress(that, process, progressOptions) {
+    let completedPercent = progressOptions.incrementProgress(process.progressPercentIncrease);
+    if (completedPercent < 100) {
+      setTimeout(that.incrementProgress, process.progressInterval, that, process, progressOptions);
+    } else {
+      if (process.terminateProgressDailog) {
+        process.terminateProgressDailog();
+      } else {
+        progressOptions.closeDialog();
+      }
+    }
   }
 }

--- a/sample/src/progress.css
+++ b/sample/src/progress.css
@@ -1,0 +1,18 @@
+.progress-bar {
+  background-color: black;
+  border-radius: 13px; /* (height of inner div) / 2 + padding */
+  padding: 3px;
+}
+
+.progress-bar > div {
+  background-color: orange;
+  width: 0%;
+  height: 20px;
+  border-radius: 10px;
+}
+
+.progress-message {
+  text-align: center;
+  margin: 18px;
+  font-size: 20px;
+}

--- a/sample/src/progress.html
+++ b/sample/src/progress.html
@@ -1,0 +1,17 @@
+<template>
+  <require from='./progress.css'></require>
+  <ai-dialog>
+    <ai-dialog-body>
+      <div class='blockPageDialog'>
+        <div class='progress-message'>${waitMessage}</div>
+        <!-- <i class="fa fa-spinner fa-spin"></i>  -->
+        <div class="progress-bar progress">
+          <div css="width: ${completedPercent}%"></div>
+        </div>
+      </div>
+    </ai-dialog-body>
+    <ai-dialog-footer>
+      <button click.trigger="controller.cancel()">Cancel</button>
+    </ai-dialog-footer>
+  </ai-dialog>
+</template>

--- a/sample/src/progress.js
+++ b/sample/src/progress.js
@@ -1,0 +1,29 @@
+import {DialogController} from 'aurelia-dialog';
+
+export class Progress {
+  static inject = [DialogController];
+
+  constructor(controller) {
+    this.controller = controller;
+  }
+
+  activate(progressOptions) {
+    this.progressOptions = progressOptions;
+    this.waitMessage = progressOptions.waitMessage || 'Waiting';
+    this.completedPercent = 0;
+
+    let that = this;
+    progressOptions.incrementProgress = (percentIncrease) => {
+      that.completedPercent += percentIncrease;
+      return that.completedPercent;
+    }
+
+    progressOptions.closeDialog = () => {
+      that.controller.close(true, null)
+        .catch((error) => {
+          //dont care if close failed
+          console.log("Error: controller.close threw error: " + error);
+        });
+    }
+  }
+}

--- a/src/dialog-options.js
+++ b/src/dialog-options.js
@@ -1,5 +1,11 @@
+
+/**
+ * Dialog Options for end consumer
+ * @param showDialogTimeout Should be just greater than dialog.css ai-dialog-container transition duration.
+ */
 export let dialogOptions = {
   lock: true,
   centerHorizontalOnly: false,
-  startingZIndex: 1000
+  startingZIndex: 1000,
+  showDialogTimeout: 250
 };

--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -41,11 +41,13 @@ export class DialogService {
 
       childContainer.registerInstance(DialogController, dialogController);
 
-      return this._getViewModel(instruction).then(returnedInstruction => {
+      _settings.model.showDialogPromise = this._getViewModel(instruction).then(returnedInstruction => {
         dialogController.viewModel = returnedInstruction.viewModel;
 
         return invokeLifecycle(returnedInstruction.viewModel, 'canActivate', _settings.model).then(canActivate => {
-          if (canActivate) {
+          if (!canActivate) {
+            return false;
+          } else {
             this.controllers.push(dialogController);
             this.hasActiveDialog = !!this.controllers.length;
 
@@ -58,6 +60,8 @@ export class DialogService {
               dialogController.slot.add(dialogController.view);
 
               return this.renderer.showDialog(dialogController);
+            }).then(() => {
+              return true;
             });
           }
         });

--- a/src/renderers/dialog-renderer.js
+++ b/src/renderers/dialog-renderer.js
@@ -82,15 +82,17 @@ export class DialogRenderer {
       };
 
       return new Promise((resolve) => {
-        modalContainer.addEventListener(transitionEvent, onTransitionEnd);
+        modalContainer.addEventListener(transitionEvent, this.onShowTransitionEnd);
 
-        function onTransitionEnd(e) {
-          if (e.target !== modalContainer) {
+        this.onShowTransitionEnd = (e) => {
+          if (e && e.target !== modalContainer) {
             return;
           }
-          modalContainer.removeEventListener(transitionEvent, onTransitionEnd);
+          modalContainer.removeEventListener(transitionEvent, this.onShowTransitionEnd);
           resolve();
         }
+
+        setTimeout(this.onShowTransitionEnd, settings.showDialogTimeout);
 
         modalOverlay.classList.add('active');
         modalContainer.classList.add('active');
@@ -103,6 +105,8 @@ export class DialogRenderer {
       if (i !== -1) {
         this.dialogControllers.splice(i, 1);
       }
+
+      this.onShowTransitionEnd();
 
       return new Promise((resolve) => {
         modalContainer.addEventListener(transitionEvent, onTransitionEnd);

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -5,12 +5,14 @@ import {configure} from '../../src/aurelia-dialog';
 let defaultSettings = {
   lock: true,
   centerHorizontalOnly: false,
-  startingZIndex: 1000
+  startingZIndex: 1000,
+  showDialogTimeout: 250
 };
 let newSettings = {
   lock: false,
   centerHorizontalOnly: true,
-  startingZIndex: 1
+  startingZIndex: 1,
+  showDialogTimeout: 300
 };
 
 let frameworkConfig = {


### PR DESCRIPTION
For progress dialogs: allow fast code close. Fix for #137

Ensure show & close always complete
add options.showDialogTimeout
return model.showDialogPromise

Includes documentation changes and sample demos.
Sample demo includes faulty usage button, to show the problem if showDialogPromise is not used.