### PR TITLE
Fix #147

### DIFF
--- a/src/styles/dialog.less
+++ b/src/styles/dialog.less
@@ -35,10 +35,6 @@ ai-dialog-container {
   & > div > div {
     width: 100%;
     display: block;
-    box-shadow: 0 5px 15px rgba(0,0,0,.5);
-    border: 1px solid rgba(0,0,0,.2);
-    border-radius: 5px;
-    padding: 3;
     min-width: 300px;
     width: -moz-fit-content;
     width: -webkit-fit-content;


### PR DESCRIPTION
remove unnecessary (and incorrect) styling on the div that is difficult to style from user space

closes #147 - it is a particular hazard in IE / Edge where the min-width calculations are not calculated correctly