### PR TITLE
fix(dialog-service): add host element to container

### DIFF
--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -31,13 +31,15 @@ export class DialogService {
       let childContainer = this.container.createChild();
       dialogController = new DialogController(childContainer.get(Renderer), settings, resolve, reject);
       childContainer.registerInstance(DialogController, dialogController);
+      let host = dialogController._renderer.getDialogContainer();
 
       let instruction = {
         container: this.container,
         childContainer: childContainer,
         model: dialogController.settings.model,
         viewModel: dialogController.settings.viewModel,
-        viewSlot: new ViewSlot(dialogController._renderer.getDialogContainer(), true)
+        viewSlot: new ViewSlot(host, true),
+        host: host
       };
 
       return _getViewModel(instruction, this.compositionEngine).then(returnedInstruction => {


### PR DESCRIPTION
Dialog Service was not adding the host element to the instruction passed to compose(). This fixes that issue.

Fixes #150.