### PR TITLE
fix(dialogResult): export DialogResult for dts

### DIFF
--- a/src/dialog-controller.js
+++ b/src/dialog-controller.js
@@ -67,7 +67,7 @@ export class DialogController {
   }
 }
 
-class DialogResult {
+export class DialogResult {
   wasCancelled: boolean = false;
   output: any;
   constructor(cancelled: boolean, result: any) {


### PR DESCRIPTION
The DialogResult class was missing an export keyword, making the class internal to the library. The babel-dts-generator does not generate types for classes that are not exported. Exporting the class fixes this issue without requiring an interface definition.

Fixes #134.