### PR TITLE
Fix renderer position test: avoid console error

### DIFF
--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -50,7 +50,7 @@ describe('the Dialog Renderer', () => {
     let controller = new DialogController(renderer, settings, Function.prototype, Function.prototype);
     controller.slot = {
       attached: Function.prototype,
-      anchor: document.createElement('ai-dialog-container')
+      anchor: document.createElement('ai-dialog')
     };
 
     renderer.showDialog(controller);


### PR DESCRIPTION
renderer position test was raising console error: Unhandled promise
rejection TypeError: Cannot read property 'addEventListener' of null