### PR TITLE
Add view to DialogService

### DIFF
--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -54,10 +54,8 @@ export class DialogService {
 
             return this.compositionEngine.compose(returnedInstruction).then(controller => {
               dialogController.controller = controller;
+              dialogController.view = controller.view;
 
-              if (!dialogController.view) {
-                dialogController.view = controller.view;
-              }
               return dialogController._renderer.showDialog(dialogController);
             });
           }

--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -37,6 +37,7 @@ export class DialogService {
         container: this.container,
         childContainer: childContainer,
         model: dialogController.settings.model,
+        view: dialogController.settings.view,
         viewModel: dialogController.settings.viewModel,
         viewSlot: new ViewSlot(host, true),
         host: host
@@ -53,8 +54,10 @@ export class DialogService {
 
             return this.compositionEngine.compose(returnedInstruction).then(controller => {
               dialogController.controller = controller;
-              dialogController.view = controller.view;
 
+              if (!dialogController.view) {
+                dialogController.view = controller.view;
+              }
               return dialogController._renderer.showDialog(dialogController);
             });
           }


### PR DESCRIPTION
Is it possible to add 'view' to DialogService? 

Doesn't look like it would be much of a change. This way you could have separate views with the same view-model. Similar to how compose works.

`this.dialogService.open({ view: './add-item-input.html', viewModel: AddItem, model: { firstName: 'Owen', testScrolling: this.showExtraData }}).then((result) => {
      if (!result.wasCancelled) {
        console.log('good');
        console.log(result.output);
      } else {
        console.log('bad');
      }
    });`