### PR TITLE
fix(dialog-configuration): Correct useRenderer typing

### DIFF
--- a/src/dialog-configuration.js
+++ b/src/dialog-configuration.js
@@ -64,7 +64,7 @@ export class DialogConfiguration {
    * @param settings Global settings for the renderer.
    * @return This instance.
    */
-  useRenderer(renderer: Renderer, settings?: Object): DialogConfiguration {
+  useRenderer(renderer: typeof Renderer, settings?: Object): DialogConfiguration {
     this.renderer = renderer;
     this.settings = Object.assign(this.settings, settings || {});
     return this;


### PR DESCRIPTION
This commit should fail today, as there is an issue with the babel-dts-generator (here https://github.com/YoloDev/babel-dts-generator/issues/54). However, the typing is accurate, and the current typing is in fact a mistake and throws compiler errors in TypeScript.