### PR TITLE
Expose controllers and hasActiveDialog to TypeScript definitions

### DIFF
--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -12,6 +12,15 @@ import {DialogResult} from './dialog-result';
 export class DialogService {
   static inject = [Container, CompositionEngine];
 
+  /**
+   * The current dialog controllers
+   */
+  controllers: DialogController[];
+  /**
+   * Is there an active dialog
+   */
+  hasActiveDialog: boolean;
+  
   constructor(container: Container, compositionEngine: CompositionEngine) {
     this.container = container;
     this.compositionEngine = compositionEngine;


### PR DESCRIPTION
We have a use case where we need to know if the DialogService has any active dialogs so that we can change our back button navigation handling.

We are consuming the code through TypeScript and need the hasActiveDialog and controllers exposed in the .d.ts

