### PR TITLE
fix(dialog-configuration): do not inject empty styling

### DIFF
--- a/src/dialog-configuration.js
+++ b/src/dialog-configuration.js
@@ -84,6 +84,8 @@ export class DialogConfiguration {
   _apply() {
     this.aurelia.singleton(Renderer, this.renderer);
     this.resources.forEach(resourceName => this.aurelia.globalResources(resources[resourceName]));
-    DOM.injectStyles(this.cssText);
+    if (this.cssText !== null && this.cssText.length > 0) {
+      DOM.injectStyles(this.cssText);
+    }
   }
 }


### PR DESCRIPTION
Previously an empty `<style>` tag would be injected into the header if the
plugin was configured with no styling instructions.