### PR TITLE
fix(dialog-configuration): register renderer as transient

### DIFF
--- a/src/dialog-configuration.js
+++ b/src/dialog-configuration.js
@@ -82,7 +82,7 @@ export class DialogConfiguration {
   }
 
   _apply() {
-    this.aurelia.singleton(Renderer, this.renderer);
+    this.aurelia.transient(Renderer, this.renderer);
     this.resources.forEach(resourceName => this.aurelia.globalResources(resources[resourceName]));
     
     if (this.cssText) {

--- a/test/unit/dialog-configuration.spec.js
+++ b/test/unit/dialog-configuration.spec.js
@@ -8,7 +8,7 @@ let defaultDialogOptions = Object.assign({}, dialogOptions);
 
 let aurelia = {
   globalResources: () => {},
-  singleton: () => {}
+  transient: () => {}
 };
 
 describe('DialogConfiguration', () => {
@@ -24,12 +24,12 @@ describe('DialogConfiguration', () => {
   });
 
   describe('useRenderer', () => {
-    it('should register a renderer as a singleton', () => {
+    it('should register a renderer as a transient', () => {
       let renderer = {};
-      spyOn(aurelia, 'singleton');
+      spyOn(aurelia, 'transient');
       configuration.useRenderer(renderer);
       configuration._apply();
-      expect(aurelia.singleton).toHaveBeenCalledWith(Renderer, renderer);
+      expect(aurelia.transient).toHaveBeenCalledWith(Renderer, renderer);
     });
 
     it('should export settings', () => {

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -18,7 +18,7 @@ let newSettings = {
 };
 
 let frameworkConfig = {
-  singleton: () => {},
+  transient: () => {},
   globalResources: () => {},
   container: {
     registerInstance: (Type, callback) => {},

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -7,7 +7,7 @@ describe('testing aurelia configure routine', () => {
       registerInstance: (Type, callback) => { },
       get: (type) => { return new Type(); }
     },
-    singleton: () => {}
+    transient: () => {}
   };
 
   it('should export configure function', () => {


### PR DESCRIPTION
The renderer is now intended to be used per opened dialog (see 67e84f0). The configuration of the dialog plugin was not updated with that change and the registration of the renderer was still singleton. This PR updates the registration to transient.

closes aurelia/dialog#180