### PR TITLE
fix(dialog-service): .open() proper error propagation

### DIFF
--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -100,6 +100,9 @@ function _openDialog(service, childContainer, dialogController) {
           dialogController.view = controller.view;
 
           return dialogController.renderer.showDialog(dialogController);
+        }).catch(e => {
+          _removeController(service, dialogController);
+          return Promise.reject(e);
         });
       }
     });

--- a/test/unit/dialog-service.spec.js
+++ b/test/unit/dialog-service.spec.js
@@ -70,4 +70,12 @@ describe('the Dialog Service', () => {
 
     dialogService.open(settings);
   });
+
+  it('".open" properly propagates errors', (done) => {
+    dialogService.open({ viewModel: 'test/fixtures/non-existent' }).catch(done);
+  });
+
+  it('".openAndYieldController" properly propagates errors', (done) => {
+    dialogService.openAndYieldController({ viewModel: 'test/fixtures/non-existent' }).catch(done);
+  });
 });


### PR DESCRIPTION
Correcting the promise chain in `.open()` to properly propagate errors.