### PR TITLE
fix(dialog-renderer): do not track controllers per renderer instance

### DIFF
--- a/src/dialog-controller.js
+++ b/src/dialog-controller.js
@@ -58,7 +58,7 @@ export class DialogController {
    * @returns Promise An empty promise object.
    */
   close(ok: boolean, output?: any): Promise<DialogResult> {
-    if (this._closePromise) { 
+    if (this._closePromise) {
       return this._closePromise;
     }
 

--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -1,4 +1,3 @@
-import {dialogOptions} from './dialog-options';
 import {DOM} from 'aurelia-pal';
 import {transient} from 'aurelia-dependency-injection';
 
@@ -39,16 +38,12 @@ export class DialogRenderer {
     }
   };
 
-  constructor() {
-    this.defaultSettings = dialogOptions;
-  }
-
   getDialogContainer() {
     return DOM.createElement('div');
   }
 
   showDialog(dialogController: DialogController) {
-    let settings = Object.assign({}, this.defaultSettings, dialogController.settings);
+    let settings = dialogController.settings;
     let body = DOM.querySelectorAll('body')[0];
     let wrapper = document.createElement('div');
 
@@ -72,8 +67,8 @@ export class DialogRenderer {
       centerDialog(this.modalContainer);
     };
 
-    this.modalOverlay.style.zIndex = this.defaultSettings.startingZIndex;
-    this.modalContainer.style.zIndex = this.defaultSettings.startingZIndex;
+    this.modalOverlay.style.zIndex = settings.startingZIndex;
+    this.modalContainer.style.zIndex = settings.startingZIndex;
 
     let lastContainer = Array.from(body.querySelectorAll(containerTagName)).pop();
 
@@ -125,7 +120,7 @@ export class DialogRenderer {
   }
 
   hideDialog(dialogController: DialogController) {
-    let settings = Object.assign({}, this.defaultSettings, dialogController.settings);
+    let settings = dialogController.settings;
     let body = DOM.querySelectorAll('body')[0];
 
     this.modalContainer.removeEventListener('click', this.closeModalClick);

--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -26,18 +26,19 @@ let transitionEvent = (function() {
   };
 }());
 
+let dialogControllers = [];
+
+function escapeKeyEvent(e) {
+  if (e.keyCode === 27) {
+    let top = dialogControllers[dialogControllers.length - 1];
+    if (top && top.settings.lock !== true) {
+      top.cancel();
+    }
+  }
+}
+
 @transient()
 export class DialogRenderer {
-  dialogControllers = [];
-  escapeKeyEvent = (e) => {
-    if (e.keyCode === 27) {
-      let top = this.dialogControllers[this.dialogControllers.length - 1];
-      if (top && top.settings.lock !== true) {
-        top.cancel();
-      }
-    }
-  };
-
   getDialogContainer() {
     return DOM.createElement('div');
   }
@@ -80,11 +81,11 @@ export class DialogRenderer {
       body.insertBefore(this.modalOverlay, body.firstChild);
     }
 
-    if (!this.dialogControllers.length) {
-      DOM.addEventListener('keyup', this.escapeKeyEvent);
+    if (!dialogControllers.length) {
+      DOM.addEventListener('keyup', escapeKeyEvent);
     }
 
-    this.dialogControllers.push(dialogController);
+    dialogControllers.push(dialogController);
 
     dialogController.slot.attached();
 
@@ -126,13 +127,13 @@ export class DialogRenderer {
     this.modalContainer.removeEventListener('click', this.closeModalClick);
     this.anchor.removeEventListener('click', this.stopPropagation);
 
-    let i = this.dialogControllers.indexOf(dialogController);
+    let i = dialogControllers.indexOf(dialogController);
     if (i !== -1) {
-      this.dialogControllers.splice(i, 1);
+      dialogControllers.splice(i, 1);
     }
 
-    if (!this.dialogControllers.length) {
-      DOM.removeEventListener('keyup', this.escapeKeyEvent);
+    if (!dialogControllers.length) {
+      DOM.removeEventListener('keyup', escapeKeyEvent);
     }
 
     return new Promise((resolve) => {
@@ -156,7 +157,7 @@ export class DialogRenderer {
         body.removeChild(this.modalContainer);
         dialogController.slot.detached();
 
-        if (!this.dialogControllers.length) {
+        if (!dialogControllers.length) {
           body.classList.remove('ai-dialog-open');
         }
 

--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -26,19 +26,17 @@ let transitionEvent = (function() {
   };
 }());
 
-let dialogControllers = [];
-
-function escapeKeyEvent(e) {
-  if (e.keyCode === 27) {
-    let top = dialogControllers[dialogControllers.length - 1];
-    if (top && top.settings.lock !== true) {
-      top.cancel();
-    }
-  }
-}
-
 @transient()
 export class DialogRenderer {
+  _escapeKeyEventHandler = (e) => {
+    if (e.keyCode === 27) {
+      let top = this._dialogControllers[this._dialogControllers.length - 1];
+      if (top && top.settings.lock !== true) {
+        top.cancel();
+      }
+    }
+  }
+
   getDialogContainer() {
     return DOM.createElement('div');
   }
@@ -81,11 +79,11 @@ export class DialogRenderer {
       body.insertBefore(this.modalOverlay, body.firstChild);
     }
 
-    if (!dialogControllers.length) {
-      DOM.addEventListener('keyup', escapeKeyEvent);
+    if (!this._dialogControllers.length) {
+      DOM.addEventListener('keyup', this._escapeKeyEventHandler);
     }
 
-    dialogControllers.push(dialogController);
+    this._dialogControllers.push(dialogController);
 
     dialogController.slot.attached();
 
@@ -127,13 +125,13 @@ export class DialogRenderer {
     this.modalContainer.removeEventListener('click', this.closeModalClick);
     this.anchor.removeEventListener('click', this.stopPropagation);
 
-    let i = dialogControllers.indexOf(dialogController);
+    let i = this._dialogControllers.indexOf(dialogController);
     if (i !== -1) {
-      dialogControllers.splice(i, 1);
+      this._dialogControllers.splice(i, 1);
     }
 
-    if (!dialogControllers.length) {
-      DOM.removeEventListener('keyup', escapeKeyEvent);
+    if (!this._dialogControllers.length) {
+      DOM.removeEventListener('keyup', this._escapeKeyEventHandler);
     }
 
     return new Promise((resolve) => {
@@ -157,7 +155,7 @@ export class DialogRenderer {
         body.removeChild(this.modalContainer);
         dialogController.slot.detached();
 
-        if (!dialogControllers.length) {
+        if (!this._dialogControllers.length) {
           body.classList.remove('ai-dialog-open');
         }
 
@@ -165,6 +163,8 @@ export class DialogRenderer {
       });
   }
 }
+
+DialogRenderer.prototype._dialogControllers = []; // will be shared by all instances
 
 function centerDialog(modalContainer) {
   const child = modalContainer.children[0];

--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -5,6 +5,7 @@ import {DialogController} from './dialog-controller';
 import {Renderer} from './renderer';
 import {invokeLifecycle} from './lifecycle';
 import {DialogResult} from './dialog-result';
+import {dialogOptions} from './dialog-options';
 
 /**
  * A service allowing for the creation of dialogs.
@@ -37,7 +38,7 @@ export class DialogService {
     let childContainer = this.container.createChild();
     let dialogController;
     let promise = new Promise((resolve, reject) => {
-      dialogController = new DialogController(childContainer.get(Renderer), settings, resolve, reject);
+      dialogController = new DialogController(childContainer.get(Renderer), _createSettings(settings), resolve, reject);
     });
     childContainer.registerInstance(DialogController, dialogController);
 
@@ -57,7 +58,7 @@ export class DialogService {
    */
   openAndYieldController(settings?: Object): Promise<DialogController> {
     let childContainer = this.container.createChild();
-    let dialogController = new DialogController(childContainer.get(Renderer), settings, null, null);
+    let dialogController = new DialogController(childContainer.get(Renderer), _createSettings(settings), null, null);
     childContainer.registerInstance(DialogController, dialogController);
 
     dialogController.result = new Promise((resolve, reject) => {
@@ -72,6 +73,12 @@ export class DialogService {
       return dialogController;
     });
   }
+}
+
+function _createSettings(settings) {
+  settings = Object.assign({}, dialogOptions, settings);
+  settings.startingZIndex = dialogOptions.startingZIndex; // should be set only when configuring the plugin
+  return settings;
 }
 
 function _openDialog(service, childContainer, dialogController) {

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -4,34 +4,7 @@ import {dialogOptions} from '../../src/dialog-options';
 import {configure} from '../../src/aurelia-dialog';
 import {TestElement} from '../fixtures/test-element';
 
-let defaultSettings = {
-  lock: true,
-  centerHorizontalOnly: false,
-  startingZIndex: 1000,
-  ignoreTransitions: false
-};
-let newSettings = {
-  lock: false,
-  centerHorizontalOnly: true,
-  startingZIndex: 1,
-  ignoreTransitions: false
-};
-
-let frameworkConfig = {
-  transient: () => {},
-  globalResources: () => {},
-  container: {
-    registerInstance: (Type, callback) => {},
-    get: (type) => { return new Type(); }
-  }
-};
-
 describe('the Dialog Renderer', () => {
-  it('uses the default settings', () => {
-    let renderer = new DialogRenderer();
-    expect(renderer.defaultSettings).toEqual(defaultSettings);
-  });
-
   it('calls position if specified', (done) => {
     const settings = {
       viewModel: TestElement,
@@ -50,16 +23,5 @@ describe('the Dialog Renderer', () => {
     };
 
     renderer.showDialog(controller);
-  });
-
-  it('allows overriding the default settings', () => {
-    let callback = (config) => {
-      config.settings = Object.assign(dialogOptions, newSettings);
-    };
-
-    configure(frameworkConfig, callback);
-    let renderer = new DialogRenderer();
-
-    expect(renderer.defaultSettings).toEqual(newSettings);
   });
 });

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -1,3 +1,4 @@
+import {DOM} from 'aurelia-pal';
 import {DialogController} from '../../src/dialog-controller';
 import {DialogRenderer} from '../../src/dialog-renderer';
 import {dialogOptions} from '../../src/dialog-options';
@@ -5,23 +6,173 @@ import {configure} from '../../src/aurelia-dialog';
 import {TestElement} from '../fixtures/test-element';
 
 describe('the Dialog Renderer', () => {
-  it('calls position if specified', (done) => {
+  function createDialogController(controllerSettings) {
+    const controller = new DialogController(new DialogRenderer(), controllerSettings, Function.prototype, Function.prototype);
+    controller.viewModel = {};
+    controller.controller = { unbind: Function.prototype };
+    controller.slot = {
+      attached: Function.prototype,
+      detached: Function.prototype,
+      anchor: document.createElement('ai-dialog')
+    };
+    return controller;
+  }
+
+  beforeAll(function () {
+    this.showDialogs = (dialogControllers) => {
+      return Promise.all(dialogControllers.map((controller) => controller.renderer.showDialog(controller)))
+        .catch(() => { this.catchWasCalled = true; });
+    };
+
+    this.closeDialog = (dialogController) => {
+      return dialogController.cancel().catch(() => { this.catchWasCalled = true; });
+    };
+  });
+
+  beforeEach(function () {
+    DialogRenderer.prototype._dialogControllers = [];
+    this.catchWasCalled = false;
+  });
+
+  it('calls position if specified', function (done) {
     const settings = {
       viewModel: TestElement,
+      ignoreTransitions: true, // ".position()" invocation is transitions independent
       position: (modalContainer, modalOverlay) => {
         expect(modalContainer.tagName).toBe('AI-DIALOG-CONTAINER');
         expect(modalOverlay.tagName).toBe('AI-DIALOG-OVERLAY');
-        done();
       }
     };
 
-    let renderer = new DialogRenderer();
-    let controller = new DialogController(renderer, settings, Function.prototype, Function.prototype);
-    controller.slot = {
-      attached: Function.prototype,
-      anchor: document.createElement('ai-dialog')
-    };
+    let controller = createDialogController(settings);
+    this.showDialogs([controller]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      done();
+    });
+  });
 
-    renderer.showDialog(controller);
+  it('does close the top dialog, when not locked, on ESC', function (done) {
+    const settings = { lock: false };
+    const expectedEndCount = 1;
+    const first = createDialogController(settings);
+    const last = createDialogController(settings);
+
+    spyOn(first, 'cancel');
+    spyOn(last, 'cancel').and.callFake((...args) => {
+      this.catchWasCalled ? done() : DialogController.prototype.cancel.apply(last, args).then(() => {
+        expect(first.cancel).not.toHaveBeenCalled();
+        expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+      }).catch(() => {
+        this.catchWasCalled = true;
+      }).then(() => {
+        expect(this.catchWasCalled).toBe(false);
+        done();
+      });
+    });
+
+    this.showDialogs([first, last]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      expect(last.renderer._dialogControllers.length).toBe(expectedEndCount + 1);
+      last.renderer._escapeKeyEventHandler({ keyCode: 27 });
+    });
+  });
+
+  it('does not close the top dialog, when locked, on ESC', function (done) {
+    const settings = { lock: true };
+    const expectedEndCount = 2;
+    const first = createDialogController(settings);
+    const last = createDialogController(settings);
+
+    spyOn(first, 'cancel');
+    spyOn(last, 'cancel');
+
+    this.showDialogs([first, last]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+      last.renderer._escapeKeyEventHandler({ keyCode: 27 });
+      expect(first.cancel).not.toHaveBeenCalled();
+      expect(last.cancel).not.toHaveBeenCalled();
+      expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+      done();
+    });
+  });
+
+  it('does add the "ai-dialog-open" class on first open dialog', function (done) {
+    const body = DOM.querySelectorAll('body')[0];
+    spyOn(body.classList, 'add').and.callThrough();
+    const controller = createDialogController({});
+
+    this.showDialogs([controller]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      expect(body.classList.add).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('does remove the "ai-dialog-open" class on last closed dialog', function (done) {
+    const body = DOM.querySelectorAll('body')[0];
+    spyOn(body.classList, 'remove').and.callThrough();
+    const controller = createDialogController({});
+
+    this.showDialogs([controller]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      this.closeDialog(controller).then(() => {
+        expect(this.catchWasCalled).toBe(false);
+        if (this.catchWasCalled) { return done(); }
+        expect(body.classList.remove).toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  it('does not remove the "ai-dialog-open" class when closed dialog is not last', function (done) {
+    const body = DOM.querySelectorAll('body')[0];
+    spyOn(body.classList, 'remove').and.callThrough();
+    const first = createDialogController({});
+    const last = createDialogController({});
+
+    this.showDialogs([first, last]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      this.closeDialog(last).then(() => {
+        expect(this.catchWasCalled).toBe(false);
+        if (this.catchWasCalled) { return done(); }
+        expect(body.classList.remove).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  it('adds ESC key event handler only on first open dialog', function (done) {
+    spyOn(DOM, 'addEventListener');
+    const first = createDialogController({});
+    const last = createDialogController({});
+
+    this.showDialogs([first, last]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      expect(DOM.addEventListener.calls.count()).toBe(1);
+      done();
+    });
+  });
+
+  it('removes ESC key event handler on last closed dialog', function (done) {
+    spyOn(DOM, 'removeEventListener');
+    const first = createDialogController({});
+
+    this.showDialogs([first]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      this.closeDialog(first).then(() => {
+        expect(this.catchWasCalled).toBe(false);
+        if (this.catchWasCalled) { return done(); }
+        expect(DOM.removeEventListener.calls.count()).toBe(1);
+        done();
+      });
+    });
   });
 });

--- a/test/unit/dialog-service.spec.js
+++ b/test/unit/dialog-service.spec.js
@@ -6,13 +6,14 @@ import {TestElement} from '../fixtures/test-element';
 import {Loader} from 'aurelia-loader';
 import {DefaultLoader} from 'aurelia-loader-default';
 import {TemplatingBindingLanguage} from 'aurelia-templating-binding';
+import {dialogOptions} from '../../src/dialog-options';
 
 describe('the Dialog Service', () => {
   let dialogService;
   let container;
   let compEng;
   let renderer;
-
+  
   beforeEach(() => {
     renderer = {
       showDialog: function() {
@@ -31,6 +32,40 @@ describe('the Dialog Service', () => {
 
     compEng = container.get(CompositionEngine);
     dialogService = new DialogService(container, compEng, renderer);
+  });
+
+  it('uses the default settings', (done) => {
+    spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
+      expect(dialogController.settings).toEqual(jasmine.objectContaining(dialogOptions));
+      done();
+    });
+
+    dialogService.open({ viewModel: TestElement });
+  });
+
+  it('allows overriding the default settings', (done) => {
+    const newSettings = {
+      lock: !dialogOptions.lock,
+      centerHorizontalOnly: !dialogOptions.centerHorizontalOnly,
+      // startingZIndex: 1, // should be overrided only when configuring the plugin
+      ignoreTransitions: !dialogOptions.ignoreTransitions
+    };
+
+    spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
+      expect(dialogController.settings).toEqual(jasmine.objectContaining(newSettings));
+      done();
+    });
+
+    dialogService.open(Object.assign({}, newSettings, { viewModel: TestElement }));
+  });
+
+  it('does not allow overriding "startingZIndex"', (done) => {
+    spyOn(renderer, 'showDialog').and.callFake((dialogController) => {
+      expect(dialogController.settings).toEqual(jasmine.objectContaining(dialogOptions));
+      done();
+    });
+
+    dialogService.open({ startingZIndex: 1, viewModel: TestElement });
   });
 
   it('open with a model settings applied', (done) => {


### PR DESCRIPTION
fix #199, #207, #211 
From what I understand, currently the relationship renderer:controller should be 1:1, but the renderer is setup to track multiple controllers per instance. So when `ESC` is pressed every renderer closes its last controller - all controllers/dialogs get closed.