### PR TITLE
fix(dialog-service): fix remove controllers closed with .error

### DIFF
--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -55,10 +55,9 @@ export class DialogService {
     dialogController.result = promise;
     dialogController.result.then(() => {
       _removeController(this, dialogController);
-    }).catch(() => {
+    }, () => {
       _removeController(this, dialogController);
     });
-
     return _openDialog(this, childContainer, dialogController)
       .then(() => dialogController);
   }


### PR DESCRIPTION
- fix dialogs closed with `DialogController.error` should also be removed from `DialogService.controllers`
- fix controllers should be added to `DialogService.controllers` after the view model has activated(after `CompositionEngine.compose()` succeeds) - if not why is `DialogService.hasActiveDialog` computed from `DialogService.controllers.length`?
- refactor `DialogService.open()` to use `DialogService.openAndYieldController()` internally - nice for testing
- fix `reports no active dialog if no dialog is open` test
- add more tests