### PR TITLE
feat(dialog-service): add .closeAll()

### DIFF
--- a/src/dialog-cancel-error.js
+++ b/src/dialog-cancel-error.js
@@ -1,9 +1,9 @@
 export class DialogCancelError extends Error {
-    wasCancelled = true;
-    reason: any;
+  wasCancelled = true;
+  reason: any;
 
-    constructor(cancellationReason: any = null) {
-        super('Dialog cancelled.');
-        this.reason = cancellationReason;
-    }
+  constructor(cancellationReason: any = null) {
+    super('Operation cancelled.');
+    this.reason = cancellationReason;
+  }
 }

--- a/src/dialog-controller.js
+++ b/src/dialog-controller.js
@@ -76,11 +76,15 @@ export class DialogController {
             } else {
               this._reject(new DialogCancelError(output));
             }
-            return result;
+            return { wasCancelled: false };
           });
       }
 
       this._closePromise = undefined;
+      if (!this.settings.rejectOnCancel) {
+        return { wasCancelled: true };
+      }
+      return Promise.reject(new DialogCancelError());
     }, e => {
       this._closePromise = undefined;
       return Promise.reject(e);

--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -72,6 +72,14 @@ export class DialogService {
   closeAll(): Promise<void> {
     return Promise.all(this.controllers.map((controller) => controller.cancel().catch((reason) => reason)));
   }
+
+  /**
+   * Closes all open dialogs at the time of invocation.
+   * @return Promise A promise that settles when all dialogs have closed.
+   */
+  closeAll(): Promise<void> {
+    return Promise.all(this.controllers.map((controller) => controller.cancel().catch((reason) => reason)));
+  }
 }
 
 function _createSettings(settings) {

--- a/src/dialog-service.js
+++ b/src/dialog-service.js
@@ -64,6 +64,14 @@ export class DialogService {
 
     return settings.yieldController ? openResult : openResult.then(result => result.wasCancelled ? result : result.closeResult);
   }
+
+  /**
+   * Closes all open dialogs at the time of invocation.
+   * @return Promise A promise that settles when all dialogs have closed.
+   */
+  closeAll(): Promise<void> {
+    return Promise.all(this.controllers.map((controller) => controller.cancel().catch((reason) => reason)));
+  }
 }
 
 function _createSettings(settings) {

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -10,7 +10,7 @@ export function invokeLifecycle(instance: any, name: string, model: any) {
   if (typeof instance[name] === 'function') {
     return Promise.resolve().then(() => {
       return instance[name](model);
-    }).then(function (result) {
+    }).then(function(result) {
       if (result !== null && result !== undefined) {
         return result;
       }

--- a/test/unit/dialog-controller.spec.js
+++ b/test/unit/dialog-controller.spec.js
@@ -2,12 +2,10 @@ import {DialogController} from '../../src/dialog-controller';
 import {Container} from 'aurelia-dependency-injection';
 
 describe('the Dialog Controller', function () {
-  let dialogController;
   let renderer = {
     defaultSettings: {},
     hideDialog: Function.prototype
   };
-  let settings;
 
   function failOnRejection(promise, done) {
     promise.catch((reason) => {
@@ -16,18 +14,22 @@ describe('the Dialog Controller', function () {
     });
   }
 
-  beforeEach(function () {
-    new Container().makeGlobal();
-    settings = { name: 'Test' };
-    dialogController = new DialogController(renderer, settings, Function.prototype, Function.prototype);
+  function createDialogController(settings = {}) {
+    const dialogController = new DialogController(renderer, settings, Function.prototype, Function.prototype);
     dialogController.viewModel = {};
     dialogController.controller = {
       unbind() { }
     };
     dialogController.renderer.hideDialog = Function.prototype;
+    return dialogController;
+  }
+
+  beforeEach(function () {
+    this.dialogController = createDialogController();
   });
 
   it('should call close with success when ok method called', function () {
+    const dialogController = this.dialogController;
     let calledValue = 'Worked';
     spyOn(dialogController, 'close');
     dialogController.ok(calledValue);
@@ -35,6 +37,7 @@ describe('the Dialog Controller', function () {
   });
 
   it('should call close without success when cancel method called', function () {
+    const dialogController = this.dialogController;
     let calledValue = 'Didnt work';
     spyOn(dialogController, 'close');
     dialogController.cancel(calledValue);
@@ -42,6 +45,7 @@ describe('the Dialog Controller', function () {
   });
 
   it('should not be blocked from being closed if ".canDeactivate()" returns "false" once', function (done) {
+    const dialogController = this.dialogController;
     dialogController.viewModel = {
       canDeactivateCalls: 0,
       canDeactivate() {
@@ -60,40 +64,48 @@ describe('the Dialog Controller', function () {
     });
   });
 
-  describe('".close" method should', function () {
+  describe('".close" method should be', function () {
     beforeEach(function () {
+      this.dialogController = createDialogController();
       this.expectedOutput = {};
     });
 
-    it('resolve on success', function (done) {
-      spyOn(dialogController, '_resolve');
+    it('resolved on success', function (done) {
+      const dialogController = this.dialogController;
+      spyOn(dialogController, '_resolve').and.callFake((result) => {
+        expect(result.wasCancelled).toBe(false);
+        expect(result.output).toBe(this.expectedOutput);
+      });
       spyOn(dialogController, '_reject');
-      const result = dialogController.close(true, this.expectedOutput)
-        .then((result) => {
-          expect(result.wasCancelled).toBe(false);
-          expect(result.output).toBe(this.expectedOutput);
-          expect(dialogController._resolve).toHaveBeenCalledWith(result);
+      const pendingClose = dialogController.close(true, this.expectedOutput)
+        .then((closeOperationResult) => {
+          expect(closeOperationResult.wasCancelled).toBe(false);
+          expect(dialogController._resolve).toHaveBeenCalled();
           expect(dialogController._reject).not.toHaveBeenCalled();
           done();
         });
-      failOnRejection(result, done);
+      failOnRejection(pendingClose, done);
     });
 
-    it('resolve on cancellation if "rejectOnCancel" is false', function (done) {
-      spyOn(dialogController, '_resolve');
+    it('resolved on cancellation if "rejectOnCancel" is false', function (done) {
+      const dialogController = this.dialogController;
+      spyOn(dialogController, '_resolve').and.callFake((result) => {
+        expect(result.wasCancelled).toBe(true);
+        expect(result.output).toBe(this.expectedOutput);
+      });
       spyOn(dialogController, '_reject');
-      const result = dialogController.close(false, this.expectedOutput)
-        .then((result) => {
-          expect(result.wasCancelled).toBe(true);
-          expect(result.output).toBe(this.expectedOutput);
-          expect(dialogController._resolve).toHaveBeenCalledWith(result);
+      const pendingClose = dialogController.close(false, this.expectedOutput)
+        .then((closeOperationResult) => {
+          expect(closeOperationResult.wasCancelled).toBe(false);
+          expect(dialogController._resolve).toHaveBeenCalled();
           expect(dialogController._reject).not.toHaveBeenCalled();
           done();
         });
-      failOnRejection(result, done);
+      failOnRejection(pendingClose, done);
     });
 
-    it('resolve on cancellation if "rejectOnCancel" is true', function (done) {
+    it('resolved on cancellation if "rejectOnCancel" is true', function (done) {
+      const dialogController = this.dialogController;
       dialogController.settings.rejectOnCancel = true;
       spyOn(dialogController, '_resolve');
       spyOn(dialogController, '_reject').and.callFake((reason) => {
@@ -101,16 +113,92 @@ describe('the Dialog Controller', function () {
         expect(reason.wasCancelled).toBe(true);
         expect(reason.reason).toBe(this.expectedOutput);
       });
-      dialogController.close(false, this.expectedOutput)
-        .then((result) => {
-          expect(result.wasCancelled).toBe(true);
-          expect(result.output).toBe(this.expectedOutput);
+      const pendingClose = dialogController.close(false, this.expectedOutput)
+        .then((closeOperationResult) => {
+          expect(closeOperationResult.wasCancelled).toBe(false);
           expect(dialogController._resolve).not.toHaveBeenCalled();
           expect(dialogController._reject).toHaveBeenCalled();
           done();
-        }).catch(() => {
-          fail('".close" should be resolved when "rejectOnError" is "true".');
+        });
+      failOnRejection(pendingClose, done);
+    });
+
+    it('resolved if ".canActivate" returns false and "rejectOnCancel" is false', function (done) {
+      const dialogController = this.dialogController;
+      dialogController.viewModel.canDeactivate = () => false;
+      spyOn(dialogController, '_resolve');
+      spyOn(dialogController, '_reject');
+      const pendingClose = dialogController.close(false, this.expectedOutput)
+        .then((closeOperationResult) => {
+          expect(closeOperationResult.wasCancelled).toBe(true);
+          expect(dialogController._resolve).not.toHaveBeenCalled();
+          expect(dialogController._reject).not.toHaveBeenCalled();
           done();
+        });
+      failOnRejection(pendingClose, done);
+    });
+
+    it('rejected if ".canDeactivate" returns false and "rejectOnCancel" is true', function (done) {
+      const dialogController = this.dialogController;
+      dialogController.settings.rejectOnCancel = true;
+      dialogController.viewModel.canDeactivate = () => false;
+      spyOn(dialogController, '_resolve');
+      spyOn(dialogController, '_reject');
+      const pendingClose = dialogController.close(false, this.expectedOutput)
+        .then(() => {
+          fail('".close" should be rejected when ".canActivate" returns false and "rejectOnError" is "true".');
+          done();
+        }).catch((reason) => {
+          expect(reason.wasCancelled).toBe(true);
+          expect(reason.reason).toBeDefined();
+          expect(dialogController._resolve).not.toHaveBeenCalled();
+          expect(dialogController._reject).not.toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('".close" method should properly propagate errors', function () {
+    beforeEach(function () {
+      this.dialogController = createDialogController();
+    });
+
+    it('from ".canDeactivate"', function (done) {
+      const dialogController = this.dialogController;
+      const expectedError = new Error();
+      dialogController.viewModel.canDeactivate = () => { throw expectedError; }
+      dialogController.viewModel.deactivate = Function.prototype;
+      spyOn(dialogController, '_resolve');
+      spyOn(dialogController, '_reject');
+      spyOn(dialogController.viewModel, 'deactivate');
+      dialogController.close(true)
+        .then(() => {
+          fail('".close" should have been rejected when ".canDeactivate" errored.');
+          done();
+        }).catch((reason) => {
+          expect(dialogController._resolve).not.toHaveBeenCalled();
+          expect(dialogController._reject).not.toHaveBeenCalled();
+          expect(dialogController.viewModel.deactivate).not.toHaveBeenCalled();
+          expect(reason).toBe(expectedError);
+          done();
+        });
+    });
+
+    it('from ".deactivate"', function (done) {
+      const dialogController = this.dialogController;
+      const expectedError = new Error();
+      dialogController.viewModel.deactivate = () => { throw expectedError; }
+      spyOn(dialogController, '_resolve');
+      spyOn(dialogController, '_reject');
+      dialogController.close(true)
+        .then(() => {
+          fail('".close" should have been rejected when ".deactivate" errored.');
+          done();
+        }).catch((reason) => {
+          expect(dialogController._resolve).not.toHaveBeenCalled();
+          expect(dialogController._reject).not.toHaveBeenCalled();
+          expect(reason).toBe(expectedError);
+          done();          
         });
     });
   });

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -222,15 +222,14 @@ describe('the Dialog Renderer', () => {
       it('when "inoreTransitions" is set to "true"', function (done) {
         this.dialogController.settings.ignoreTransitions = true;
         this.expectedDuration = '0.2s';
-        this.renderer.showDialog(this.dialogController).then(done).catch(e => fail(e));;
+        this.renderer.showDialog(this.dialogController).then(done).catch(e => fail(e));
         expect(this.awaitsTransition).toBe(false);
       });
 
       it('when duration is zero', function (done) {
         this.dialogController.settings.ignoreTransitions = false;
         this.expectedDuration = '0s';
-        this.renderer.showDialog(this.dialogController).then(done).catch(e => fail(e));;
-        console.log();
+        this.renderer.showDialog(this.dialogController).then(done).catch(e => fail(e));
         expect(this.awaitsTransition).toBe(false);
       });
     });
@@ -238,7 +237,7 @@ describe('the Dialog Renderer', () => {
     it('when the transition is with non-zero duration', function (done) {
       this.dialogController.settings.ignoreTransitions = false;
       this.expectedDuration = '0.3s';
-      this.renderer.showDialog(this.dialogController).then(done).catch(e => fail(e));;
+      this.renderer.showDialog(this.dialogController).then(done).catch(e => fail(e));
       expect(this.awaitsTransition).toBe(true);
     });
   });

--- a/test/unit/dialog-service.spec.js
+++ b/test/unit/dialog-service.spec.js
@@ -319,4 +319,49 @@ describe('the Dialog Service', function () {
         });
     });
   });
+
+  it('".open" properly propagates errors', (done) => {
+    let catchWasCalled = false;
+    let promise = dialogService.open({ viewModel: 'test/fixtures/non-existent' })
+      .catch(() => {
+        catchWasCalled = true;
+      }).then(() => {
+        expect(catchWasCalled).toBe(true);
+        done();
+      });
+  });
+
+  it('reports no active dialog after ".closeAll" has been invoked', (done) => {
+    const settings = { viewModel: TestElement };
+    const dialogsToOpen = 6;
+    let i = dialogsToOpen;
+    let controllersPromises = [];
+    let controllers;
+    let catchWasCalled = false;
+
+    expect(dialogService.hasActiveDialog).toBe(false);
+    while (i--) { 
+      controllersPromises.push(dialogService.openAndYieldController(settings));
+    }
+    expect(dialogService.hasActiveDialog).toBe(false);
+    const closeAll = Promise.all(controllersPromises).then((ctrls) => {
+      controllers = ctrls;
+      ctrls.forEach((controller) => {
+        spyOn(controller, 'cancel').and.callThrough();
+      });
+      return dialogService.closeAll();
+    }).catch((reason => {
+      catchWasCalled = true;
+    })).then(() => {
+      expect(catchWasCalled).toBe(false);
+      if (catchWasCalled) {
+        return done();
+      }
+      controllers.forEach((controller) => {
+        expect(controller.cancel).toHaveBeenCalled();
+      });
+      expect(dialogService.controllers.length).toBe(0);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Add a convenience method to close all open dialogs, see #214.
