### PR TITLE
feat(dialog options): allow esc to close dialog without lock: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ export function configure(aurelia) {
       config.settings.lock = true;
       config.settings.centerHorizontalOnly = false;
       config.settings.startingZIndex = 5;
+      config.settings.enableEscClose = true;
     });
 
   aurelia.start().then(a => a.setRoot());
@@ -272,6 +273,7 @@ The settings available for the dialog are set on the dialog controller on a per-
 - `ignoreTransitions` is a Boolean you must set to `true` if you disable css animation of your dialog. (optional, default to false)
 - `yieldController` is a Boolean you must set to `true` if you want to execute some logic when the dialog gets open and/or get access to the dialog controller
 - `rejectOnCancel` is a Boolean you must set to `true` if you want to handle cancellations as rejection. The reason will be instance of `DialogCancelError` - the property `wasCancelled` will be set to `true` and if cancellation data was provided it will be set to the `reason` property.
+- `enableEscClose` allows pressings escape to close the modal without `lock: false`. (optional, defaults to true)
 
 > Warning: Plugin authors are advised to be explicit with settings that change behavior(`yieldController` and `rejectOnCancel`).
 

--- a/src/dialog-options.js
+++ b/src/dialog-options.js
@@ -4,5 +4,6 @@ export let dialogOptions = {
   startingZIndex: 1000,
   ignoreTransitions: false,
   rejectOnCancel: false,
-  yieldController: false
+  yieldController: false,
+  enableEscClose: true
 };

--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -47,7 +47,7 @@ export class DialogRenderer {
   _escapeKeyEventHandler = (e) => {
     if (e.keyCode === 27) {
       let top = this._dialogControllers[this._dialogControllers.length - 1];
-      if (top && top.settings.lock !== true) {
+      if (top && (top.settings.lock !== true && !top.settings.enableEscClose)) {
         top.cancel();
       }
     }

--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -47,7 +47,7 @@ export class DialogRenderer {
   _escapeKeyEventHandler = (e) => {
     if (e.keyCode === 27) {
       let top = this._dialogControllers[this._dialogControllers.length - 1];
-      if (top && (top.settings.lock !== true && !top.settings.enableEscClose)) {
+      if (top && (top.settings.lock !== true && top.settings.enableEscClose)) {
         top.cancel();
       }
     }

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -68,7 +68,7 @@ describe('the Dialog Renderer', () => {
   });
 
   it('does close the top dialog, when not locked, on ESC', function (done) {
-    const settings = { lock: false };
+    const settings = { lock: false, enableEscClose: true };
     const expectedEndCount = 1;
     const first = createDialogController(settings);
     const last = createDialogController(settings);
@@ -130,7 +130,7 @@ describe('the Dialog Renderer', () => {
       expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
       last.renderer._escapeKeyEventHandler({ keyCode: 27 });
       expect(first.cancel).not.toHaveBeenCalled();
-      expect(last.cancel).not.toHaveBeenCalled();
+      expect(last.cancel).toHaveBeenCalled();
       expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
       done();
     });

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -115,6 +115,48 @@ describe('the Dialog Renderer', () => {
     });
   });
 
+  it('does close the top dialog when enableEscClose is true', function (done) {
+    const settings = { enableEscClose: true, lock: false };
+    const expectedEndCount = 2;
+    const first = createDialogController(settings);
+    const last = createDialogController(settings);
+
+    spyOn(first, 'cancel');
+    spyOn(last, 'cancel');
+
+    this.showDialogs([first, last]).then(() => {
+      expect(this.catchWasCalled).toBe(false);
+      if (this.catchWasCalled) { return done(); }
+      expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+      last.renderer._escapeKeyEventHandler({ keyCode: 27 });
+      expect(first.cancel).not.toHaveBeenCalled();
+      expect(last.cancel).not.toHaveBeenCalled();
+      expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+      done();
+    });
+  });
+
+  it('does not close the top dialog when enableEscClose is false and lock is true', function (done) {
+      const settings = { enableEscClose: false, lock: true };
+      const expectedEndCount = 2;
+      const first = createDialogController(settings);
+      const last = createDialogController(settings);
+
+      spyOn(first, 'cancel');
+      spyOn(last, 'cancel');
+
+      this.showDialogs([first, last]).then(() => {
+        expect(this.catchWasCalled).toBe(false);
+        if (this.catchWasCalled) { return done(); }
+        expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+        last.renderer._escapeKeyEventHandler({ keyCode: 27 });
+        expect(first.cancel).not.toHaveBeenCalled();
+        expect(last.cancel).not.toHaveBeenCalled();
+        expect(last.renderer._dialogControllers.length).toBe(expectedEndCount);
+        done();
+      });
+    });
+
   it('does add the "ai-dialog-open" class on first open dialog', function (done) {
     const body = DOM.querySelectorAll('body')[0];
     spyOn(body.classList, 'add').and.callThrough();


### PR DESCRIPTION
Adding ability to enable esc without `lock:false`.

Referenced: https://github.com/aurelia/dialog/issues/238

@PWKad 