### PR TITLE
feat: host and childContainer settings

### DIFF
--- a/src/dialog-service.ts
+++ b/src/dialog-service.ts
@@ -140,7 +140,8 @@ export class DialogService {
   public open(settings?: DialogSettings & { rejectOnCancel?: false | boolean }): DialogOpenPromise<DialogCancellableOpenResult>;
   public open(settings: DialogSettings = {}): DialogOpenPromise<DialogCancellableOpenResult> {
     // tslint:enable:max-line-length
-    const childContainer = this.container.createChild();
+    settings = this.createSettings(settings);
+    const childContainer = settings.childContainer || this.container.createChild();
     let resolveCloseResult: any;
     let rejectCloseResult: any;
     const closeResult: Promise<DialogCloseResult> = new Promise((resolve, reject) => {
@@ -148,7 +149,7 @@ export class DialogService {
       rejectCloseResult = reject;
     });
     const dialogController =
-      childContainer.invoke(DialogController, [this.createSettings(settings), resolveCloseResult, rejectCloseResult]);
+      childContainer.invoke(DialogController, [settings, resolveCloseResult, rejectCloseResult]);
     childContainer.registerInstance(DialogController, dialogController);
     closeResult.then(() => {
       removeController(this, dialogController);

--- a/src/dialog-settings.ts
+++ b/src/dialog-settings.ts
@@ -1,3 +1,4 @@
+import { Container } from 'aurelia-dependency-injection';
 import { ViewStrategy } from 'aurelia-templating';
 
 export type ActionKey = 'Escape' | 'Enter';
@@ -27,6 +28,12 @@ export interface DialogSettings {
    * The element that will parent the dialog.
    */
   host?: Element;
+
+  /**
+   * The child Container for the dialog creation.
+   * One will be created from the root if not provided.
+   */
+  childContainer?: Container;
 
   /**
    * When set to "false" allows the dialog to be closed with ESC key or clicking outside the dialog.

--- a/src/dialog-settings.ts
+++ b/src/dialog-settings.ts
@@ -24,6 +24,11 @@ export interface DialogSettings {
   model?: any;
 
   /**
+   * The element that will parent the dialog.
+   */
+  host?: Element;
+
+  /**
    * When set to "false" allows the dialog to be closed with ESC key or clicking outside the dialog.
    * When set to "true" the dialog does not close on ESC key or clicking outside of it.
    */

--- a/test/unit/dialog-renderer.spec.ts
+++ b/test/unit/dialog-renderer.spec.ts
@@ -158,6 +158,32 @@ describe('DialogRenderer', () => {
         done();
       });
     });
+
+    describe('"host"', () => {
+      it('and when provided parents the dialog', async done => {
+        const host = DOM.createElement('div');
+        spyOn(host, 'insertBefore').and.callThrough();
+        spyOn(host, 'removeChild').and.callThrough();
+        body.appendChild(host);
+        const settings: DialogSettings = { host };
+        const renderer = createRenderer(settings);
+        await show(done, renderer);
+        expect(host.insertBefore).toHaveBeenCalledWith(renderer.dialogContainer, null);
+        expect(host.insertBefore).toHaveBeenCalledWith(renderer.dialogOverlay, renderer.dialogContainer);
+        await hide(done, renderer);
+        expect(host.removeChild).toHaveBeenCalledWith(renderer.dialogOverlay);
+        expect(host.removeChild).toHaveBeenCalledWith(renderer.dialogContainer);
+        body.removeChild(host);
+        done();
+      });
+
+      it('and when missing defaults to the "body" element', async done => {
+        const renderer = createRenderer({ host: undefined });
+        await show(done, renderer);
+        expect(renderer.host).toBe(body);
+        done();
+      });
+    });
   });
 
   describe('on first open dialog', () => {

--- a/test/unit/dialog-service.spec.ts
+++ b/test/unit/dialog-service.spec.ts
@@ -113,6 +113,23 @@ describe('DialogService', () => {
       done();
     });
 
+    it('should create new child Container if "childContainer" is missing', async done => {
+      spyOn(container, 'createChild').and.callThrough();
+      await _success(() => dialogService.open(), done);
+      expect(container.createChild).toHaveBeenCalled();
+      done();
+    });
+
+    it('should not create new child Container if "childContainer" is provided', async done => {
+      const settings = { childContainer: container.createChild() };
+      spyOn(container, 'createChild').and.callThrough();
+      spyOn(settings.childContainer, 'invoke').and.callThrough();
+      await _success(() => dialogService.open(settings), done);
+      expect(container.createChild).not.toHaveBeenCalled();
+      expect(settings.childContainer.invoke).toHaveBeenCalled();
+      done();
+    });
+
     it('propagates errors', async done => {
       const expectdError = new Error('Expected error.');
       spyOn(TestElement.prototype, 'canActivate').and.callFake(() => { throw expectdError; });

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
     "no-string-literal": false,
     "object-literal-sort-keys": false,
     "ordered-imports": [false],
+    "prefer-for-of": false,
     "quotemark": [true, "single"],
     "trailing-comma": [false],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type"]


### PR DESCRIPTION
closes #260, closes #179, closes #220
* `host: Element` - if provided the `Renderer` will attach the dialog to this element, defaults to the `body`
* `childContainer: Container`
  * the container in which the `DialogController` is registered and from which the `Renderer` is acquired
  * if not provided a child container is created from the root `Container`