### PR TITLE
refactor(dialog-service): make "rejectOnCancel" readonly

### DIFF
--- a/src/dialog-service.ts
+++ b/src/dialog-service.ts
@@ -126,6 +126,11 @@ export class DialogService {
     if (typeof settings.overlayDismiss !== 'boolean') {
       settings.overlayDismiss = !settings.lock;
     }
+    Object.defineProperty(settings, 'rejectOnCancel', {
+      writable: false,
+      configurable: true,
+      enumerable: true
+    });
     this.validateSettings(settings);
     return settings;
   }


### PR DESCRIPTION
Allowing for `rejectOnCancel` to be changed after `.open` has been called may lead to unexpected results.
```js
dialogService.open({rejectOnCancel: false}).whenClosed(result => {
  if (result.wasCancelled) {
    // do something important
    return;
  }
  // do something else
});
```
Now if someone changes `rejectOnCancel` to `true` after the above has executed, the caller of `.open` will not be able to handle the cancellation.
@PWKad Does restricting the window for changes till `.open` is called seem reasonable?