### PR TITLE
feat(dialog-controller): deactivate hook error data

### DIFF
--- a/src/dialog-close-error.ts
+++ b/src/dialog-close-error.ts
@@ -1,0 +1,15 @@
+/**
+ * The error is thrown when the dialog is closed with the `DialogController.prototype.error` method.
+ */
+export interface DialogCloseError extends Error {
+    reason: any;
+}
+
+/**
+ * @internal
+ */
+export function createDialogCloseError(reason: any): DialogCloseError {
+    const error = new Error() as DialogCloseError;
+    error.reason = reason;
+    return error;
+}

--- a/src/dialog-close-error.ts
+++ b/src/dialog-close-error.ts
@@ -1,15 +1,17 @@
 /**
- * The error is thrown when the dialog is closed with the `DialogController.prototype.error` method.
+ * The error thrown when the dialog is closed with the `DialogController.prototype.error` method.
  */
 export interface DialogCloseError extends Error {
-    reason: any;
+    wasCancelled: false;
+    output: any;
 }
 
 /**
  * @internal
  */
-export function createDialogCloseError(reason: any): DialogCloseError {
+export function createDialogCloseError(output: any): DialogCloseError {
     const error = new Error() as DialogCloseError;
-    error.reason = reason;
+    error.wasCancelled = false;
+    error.output = output;
     return error;
 }

--- a/src/dialog-controller.ts
+++ b/src/dialog-controller.ts
@@ -79,12 +79,12 @@ export class DialogController {
   }
 
   /**
-   * Closes the dialog with an error result.
-   * @param reason A reason for closing with an error.
+   * Closes the dialog with an error output.
+   * @param output A reason for closing with an error.
    * @returns Promise An empty promise object.
    */
-  public error(reason: any): Promise<void> {
-    const closeError = createDialogCloseError(reason);
+  public error(output: any): Promise<void> {
+    const closeError = createDialogCloseError(output);
     return this.releaseResources(closeError).then(() => { this.reject(closeError); });
   }
 

--- a/src/dialog-controller.ts
+++ b/src/dialog-controller.ts
@@ -3,6 +3,7 @@ import { Renderer } from './renderer';
 import { DialogCancelableOperationResult, DialogCloseResult, DialogCancelResult } from './dialog-result';
 import { DialogSettings } from './dialog-settings';
 import { invokeLifecycle } from './lifecycle';
+import { createDialogCloseError, DialogCloseError } from './dialog-close-error';
 import { createDialogCancelError } from './dialog-cancel-error';
 
 /**
@@ -45,8 +46,8 @@ export class DialogController {
   /**
    * @internal
    */
-  public releaseResources(dialogResult?: any): Promise<void> {
-    return invokeLifecycle(this.controller.viewModel || {}, 'deactivate', dialogResult)
+  public releaseResources(result: DialogCloseResult | DialogCloseError): Promise<void> {
+    return invokeLifecycle(this.controller.viewModel || {}, 'deactivate', result)
       .then(() => this.renderer.hideDialog(this))
       .then(() => { this.controller.unbind(); });
   }
@@ -79,11 +80,12 @@ export class DialogController {
 
   /**
    * Closes the dialog with an error result.
-   * @param message An error message.
+   * @param reason A reason for closing with an error.
    * @returns Promise An empty promise object.
    */
-  public error(message: any): Promise<void> {
-    return this.releaseResources().then(() => { this.reject(message); });
+  public error(reason: any): Promise<void> {
+    const closeError = createDialogCloseError(reason);
+    return this.releaseResources(closeError).then(() => { this.reject(closeError); });
   }
 
   /**
@@ -119,6 +121,6 @@ export class DialogController {
           this.closePromise = undefined;
           return Promise.reject(reason);
         });
-    });
+      });
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,5 @@
+import { DialogCloseError } from './dialog-close-error';
+import { DialogCloseResult } from './dialog-result';
 /**
  * An optional interface describing the dialog canActivate convention.
  */
@@ -29,7 +31,7 @@ export interface DialogComponentCanDeactivate {
    * To cancel the closing of the dialog return false or a promise that resolves to false.
    * Any other returned value is coerced to true.
    */
-  canDeactivate(): boolean | Promise<boolean> | PromiseLike<boolean>;
+  canDeactivate(result: DialogCloseResult): boolean | Promise<boolean> | PromiseLike<boolean>;
 }
 
 /**
@@ -39,5 +41,5 @@ export interface DialogComponentDeactivate {
   /**
    * Implement this hook if you want to perform custom logic when the dialog is being closed.
    */
-  deactivate(): void | Promise<void> | PromiseLike<void>;
+  deactivate(result: DialogCloseResult | DialogCloseError): void | Promise<void> | PromiseLike<void>;
 }

--- a/test/unit/dialog-controller.spec.ts
+++ b/test/unit/dialog-controller.spec.ts
@@ -133,10 +133,13 @@ describe('DialogController', () => {
       reason = new Error('Test reason');
     });
 
-    it('should call ".releaseResources"', async done => {
+    it('should call ".releaseResources" with "DialogCloseError"', async done => {
       spyOn(dialogController, 'releaseResources').and.returnValue(Promise.resolve());
       await _success(() => dialogController.error(reason), done);
-      expect(dialogController.releaseResources).toHaveBeenCalled();
+      expect(dialogController.releaseResources).toHaveBeenCalledWith(jasmine.objectContaining({
+        wasCancelled: false,
+        output: reason
+      }));
       done();
     });
 
@@ -147,7 +150,10 @@ describe('DialogController', () => {
       });
 
       it('call the reject callback', () => {
-        expect(rejectCallback).toHaveBeenCalledWith(reason);
+        expect(rejectCallback).toHaveBeenCalledWith(jasmine.objectContaining({
+          wasCancelled: false,
+          output: reason
+        }));
       });
 
       it('not call the resolve callback', () => {

--- a/test/unit/dialog-controller.spec.ts
+++ b/test/unit/dialog-controller.spec.ts
@@ -1,7 +1,9 @@
-import {DefaultDialogSettings} from '../../src/dialog-settings';
-import {Renderer} from '../../src/renderer';
-import {DialogController} from '../../src/dialog-controller';
-import {DialogCancelError} from '../../src/dialog-cancel-error';
+import { DialogCloseResult } from './../../src/dialog-result';
+import { DialogComponentCanDeactivate } from './../../src/interfaces';
+import { DefaultDialogSettings } from '../../src/dialog-settings';
+import { Renderer } from '../../src/renderer';
+import { DialogController } from '../../src/dialog-controller';
+import { DialogCancelError } from '../../src/dialog-cancel-error';
 
 describe('DialogController', () => {
   let resolveCallback: jasmine.Spy;
@@ -43,13 +45,14 @@ describe('DialogController', () => {
   });
 
   describe('".releaseResources" should', () => {
+    const expectedDeactivateArg = {} as any;
     beforeEach(async done => {
-      await _success(() => dialogController.releaseResources(), done);
+      await _success(() => dialogController.releaseResources(expectedDeactivateArg), done);
       done();
     });
 
     it('call ".deactivate" on the view model', () => {
-      expect((dialogController.controller.viewModel as any).deactivate).toHaveBeenCalled();
+      expect((dialogController.controller.viewModel as any).deactivate).toHaveBeenCalledWith(expectedDeactivateArg);
     });
 
     it('call ".hideDialog" on the renderer', () => {
@@ -176,6 +179,16 @@ describe('DialogController', () => {
       const expected = 'success output';
       await _success(() => dialogController.close(true, expected), done);
       expect(resolveCallback).toHaveBeenCalledWith(jasmine.objectContaining({ wasCancelled: false, output: expected }));
+      done();
+    });
+
+    it('call ".canDeactivate" with the close result', async done => {
+      const output = 'expected output';
+      await _success(() => dialogController.close(true, output), done);
+      const vm = dialogController.controller.viewModel as DialogComponentCanDeactivate;
+      const expectedResult = (vm.canDeactivate as jasmine.Spy).calls.argsFor(0)[0] as DialogCloseResult;
+      expect(expectedResult).toBeDefined();
+      expect(expectedResult.output).toBe(output);
       done();
     });
 

--- a/test/unit/dialog-service.spec.ts
+++ b/test/unit/dialog-service.spec.ts
@@ -192,7 +192,10 @@ describe('DialogService', () => {
       const expectedError = new Error('expected test error');
       controller.error(expectedError);
       const result = await _failure(() => closeResult, done);
-      expect(result).toBe(expectedError);
+      expect(result).toEqual(jasmine.objectContaining({
+        wasCancelled: false,
+        output: expectedError
+      }));
       done();
     });
 


### PR DESCRIPTION
Builds on top of #271 to provide consistent behavior to `DialogController.prototype.error` with the other *close* methods.
Main points of concern:
1. makes it easier to determine whether `DialogController.prototype.error` was called:
  - in the `.deactivate` hook
    - when `DialogController.prototype.error` is called, `.canDeactivate` is skipped.
    - `.deactivate` will be called with either `DialogCloseResult` or `DialogCloseError`(instance of `Error`)
  - in `dialogService.open({...}).whenClosed().catch()` - currently we can determine whether it is a cancellation error(`DialogCancelError`) or not(using just the error, without additional conventions, ...).
2. **breaking change** - currently `DialogController.prototype.error` accepts anything and rejects the result promise with that value. I propose that we wrap *whatever* is passed in a `DialogCloseError`, basically instance of `Error` with an additional field `reason: any` - the passed argument. It will break the current way of handling `dialogService.open({...}).whenClosed().catch()`, determining whether `DialogController.prototype.error` was called, since now the value/reason will be wrapped in a `DialogCloseError`.
  - this helps to determine  whether `.error` was called, by just checking the error param - used in **1.**

@PWKad @EisenbergEffect I would like to hear your concerns with **2.**
Will finish the tests afterwards.