### PR TITLE
fix(dialog-service): fix no fail for undefined moduleId

### DIFF
--- a/src/dialog-service.ts
+++ b/src/dialog-service.ts
@@ -78,7 +78,11 @@ export class DialogService {
 
   private ensureViewModel(compositionContext: CompositionContext): Promise<CompositionContext> {
     if (typeof compositionContext.viewModel === 'function') {
-      compositionContext.viewModel = Origin.get(compositionContext.viewModel).moduleId;
+      const moduleId = Origin.get(compositionContext.viewModel).moduleId;
+      if (!moduleId) {
+        return Promise.reject(new Error(`Can not resolve "moduleId" of "${compositionContext.viewModel.name}".`));
+      }
+      compositionContext.viewModel = moduleId;
     }
 
     if (typeof compositionContext.viewModel === 'string') {

--- a/test/unit/dialog-service.spec.ts
+++ b/test/unit/dialog-service.spec.ts
@@ -130,6 +130,12 @@ describe('DialogService', () => {
       done();
     });
 
+    it('should get rejected when the "moduleId" of the provided view model can not be resolved ', async done => {
+      const settings = { viewModel: class {} };
+      await _failure(() => dialogService.open(settings), done);
+      done();
+    });
+
     it('propagates errors', async done => {
       const expectdError = new Error('Expected error.');
       spyOn(TestElement.prototype, 'canActivate').and.callFake(() => { throw expectdError; });


### PR DESCRIPTION
When the `moduleId` of a given view model can not be resolved, reject with an error. 