### PR TITLE
Add alternative <dialog> element renderer

### DIFF
--- a/src/aurelia-dialog.ts
+++ b/src/aurelia-dialog.ts
@@ -27,3 +27,4 @@ export * from './dialog-cancel-error';
 export * from './dialog-result';
 export * from './dialog-service';
 export * from './dialog-controller';
+export { NativeDialogRenderer } from './native-dialog-renderer';

--- a/src/dialog-settings.ts
+++ b/src/dialog-settings.ts
@@ -82,7 +82,7 @@ export interface DialogSettings {
    * Usde to provide custom positioning logic.
    * When invoked the function is passed the dialog container and the dialog overlay elements.
    */
-  position?: (dialogContainer: Element, dialogOverlay: Element) => void;
+  position?: (dialogContainer: Element, dialogOverlay?: Element) => void;
 }
 
 /**

--- a/src/native-dialog-renderer.ts
+++ b/src/native-dialog-renderer.ts
@@ -1,0 +1,187 @@
+import { DOM } from 'aurelia-pal';
+import { transient } from 'aurelia-dependency-injection';
+import { Renderer } from './renderer';
+import { DialogController } from './dialog-controller';
+import { transitionEvent, hasTransition } from './dialog-renderer';
+
+const containerTagName = 'dialog';
+let body: HTMLBodyElement;
+
+@transient()
+export class NativeDialogRenderer implements Renderer {
+  public static dialogControllers: DialogController[] = [];
+
+  public static keyboardEventHandler(e: KeyboardEvent) {
+    const key = (e.code || e.key) === 'Enter' || e.keyCode === 13
+    ? 'Enter'
+    : undefined;
+
+    if (!key) { return; }
+    const top = NativeDialogRenderer.dialogControllers[NativeDialogRenderer.dialogControllers.length - 1];
+    if (!top || !top.settings.keyboard) { return; }
+    const keyboard = top.settings.keyboard;
+    if (key === 'Enter' && (keyboard === key || (Array.isArray(keyboard) && keyboard.indexOf(key) > -1))) {
+      top.ok();
+    }
+  }
+
+  public static trackController(dialogController: DialogController): void {
+    if (!NativeDialogRenderer.dialogControllers.length) {
+      DOM.addEventListener('keyup', NativeDialogRenderer.keyboardEventHandler, false);
+    }
+    NativeDialogRenderer.dialogControllers.push(dialogController);
+  }
+
+  public static untrackController(dialogController: DialogController): void {
+    const i = NativeDialogRenderer.dialogControllers.indexOf(dialogController);
+    if (i !== -1) {
+      NativeDialogRenderer.dialogControllers.splice(i, 1);
+    }
+    if (!NativeDialogRenderer.dialogControllers.length) {
+      DOM.removeEventListener('keyup', NativeDialogRenderer.keyboardEventHandler, false);
+    }
+  }
+
+  private stopPropagation: (e: MouseEvent & { _aureliaDialogHostClicked: boolean }) => void;
+  private closeDialogClick: (e: MouseEvent & { _aureliaDialogHostClicked: boolean }) => void;
+  private dialogCancel: (e: Event) => void;
+
+  public dialogContainer: HTMLDialogElement;
+  public host: Element;
+  public anchor: Element;
+
+  private getOwnElements(parent: Element, selector: string): Element[] {
+    const elements = parent.querySelectorAll(selector);
+    const own: Element[] = [];
+    for (let i = 0; i < elements.length; i++) {
+      if (elements[i].parentElement === parent) {
+        own.push(elements[i]);
+      }
+    }
+    return own;
+  }
+
+  private attach(dialogController: DialogController): void {
+    const spacingWrapper = DOM.createElement('div'); // TODO: check if redundant
+    spacingWrapper.appendChild(this.anchor);
+    this.dialogContainer = DOM.createElement(containerTagName) as HTMLDialogElement;
+    if ((window as any).dialogPolyfill) {
+      (window as any).dialogPolyfill.registerDialog(this.dialogContainer);
+    }
+
+    this.dialogContainer.appendChild(spacingWrapper);
+
+    const lastContainer = this.getOwnElements(this.host, containerTagName).pop();
+    if (lastContainer && lastContainer.parentElement) {
+      this.host.insertBefore(this.dialogContainer, lastContainer.nextSibling);
+    } else {
+      this.host.insertBefore(this.dialogContainer, this.host.firstChild);
+    }
+    dialogController.controller.attached();
+    this.host.classList.add('ux-dialog-open');
+  }
+
+  private detach(dialogController: DialogController): void {
+    // This check only seems required for the polyfill
+    if (this.dialogContainer.hasAttribute('open')) {
+      this.dialogContainer.close();
+    }
+
+    this.host.removeChild(this.dialogContainer);
+    dialogController.controller.detached();
+    if (!NativeDialogRenderer.dialogControllers.length) {
+      this.host.classList.remove('ux-dialog-open');
+    }
+  }
+
+  private setAsActive(): void {
+    this.dialogContainer.showModal();
+    this.dialogContainer.classList.add('active');
+  }
+
+  private setAsInactive(): void {
+    this.dialogContainer.classList.remove('active');
+  }
+
+  private setupEventHandling(dialogController: DialogController): void {
+    this.stopPropagation = e => { e._aureliaDialogHostClicked = true; };
+    this.closeDialogClick = e => {
+      if (dialogController.settings.overlayDismiss && !e._aureliaDialogHostClicked) {
+        dialogController.cancel();
+      }
+    };
+    this.dialogCancel = e => {
+      const keyboard = dialogController.settings.keyboard;
+      const key = 'Escape';
+
+      if (keyboard === true || keyboard === key || (Array.isArray(keyboard) && keyboard.indexOf(key) > -1)) {
+        dialogController.cancel();
+      } else {
+        e.preventDefault();
+      }
+    };
+    this.dialogContainer.addEventListener('click', this.closeDialogClick);
+    this.dialogContainer.addEventListener('cancel', this.dialogCancel);
+    this.anchor.addEventListener('click', this.stopPropagation);
+  }
+
+  private clearEventHandling(): void {
+    this.dialogContainer.removeEventListener('click', this.closeDialogClick);
+    this.dialogContainer.removeEventListener('cancel', this.dialogCancel);
+    this.anchor.removeEventListener('click', this.stopPropagation);
+  }
+
+  private awaitTransition(setActiveInactive: () => void, ignore: boolean): Promise<void> {
+    return new Promise<void>(resolve => {
+      // tslint:disable-next-line:no-this-assignment
+      const renderer = this;
+      const eventName = transitionEvent();
+      function onTransitionEnd(e: TransitionEvent): void {
+        if (e.target !== renderer.dialogContainer) {
+          return;
+        }
+        renderer.dialogContainer.removeEventListener(eventName, onTransitionEnd);
+        resolve();
+      }
+
+      if (ignore || !hasTransition(this.dialogContainer)) {
+        resolve();
+      } else {
+        this.dialogContainer.addEventListener(eventName, onTransitionEnd);
+      }
+      setActiveInactive();
+    });
+  }
+
+  public getDialogContainer(): Element {
+    return this.anchor || (this.anchor = DOM.createElement('div'));
+  }
+
+  public showDialog(dialogController: DialogController): Promise<void> {
+    if (!body) {
+      body = DOM.querySelectorAll('body')[0] as HTMLBodyElement;
+    }
+    if (dialogController.settings.host) {
+      this.host = dialogController.settings.host;
+    } else {
+      this.host = body;
+    }
+    const settings = dialogController.settings;
+    this.attach(dialogController);
+
+    if (typeof settings.position === 'function') {
+      settings.position(this.dialogContainer);
+    }
+
+    NativeDialogRenderer.trackController(dialogController);
+    this.setupEventHandling(dialogController);
+    return this.awaitTransition(() => this.setAsActive(), dialogController.settings.ignoreTransitions as boolean);
+  }
+
+  public hideDialog(dialogController: DialogController): Promise<void> {
+    this.clearEventHandling();
+    NativeDialogRenderer.untrackController(dialogController);
+    return this.awaitTransition(() => this.setAsInactive(), dialogController.settings.ignoreTransitions as boolean)
+      .then(() => { this.detach(dialogController); });
+  }
+}

--- a/test/unit/native-dialog-renderer.spec.ts
+++ b/test/unit/native-dialog-renderer.spec.ts
@@ -1,0 +1,411 @@
+import { DOM } from 'aurelia-pal';
+import { DialogController } from '../../src/dialog-controller';
+import { NativeDialogRenderer } from '../../src/native-dialog-renderer';
+import { hasTransition, transitionEvent } from '../../src/dialog-renderer';
+import { DefaultDialogSettings, DialogSettings } from '../../src/dialog-settings';
+
+type TestDialogRenderer = NativeDialogRenderer & { [key: string]: any, __controller: DialogController };
+
+const durationPropertyName = (() => {
+  let durationPropertyName: string | null;
+  return () => {
+    if (typeof durationPropertyName !== 'undefined') { return durationPropertyName; }
+    const propertyNames = ['oTransitionDuration', 'webkitTransitionDuration', 'transitionDuration']; // order matters
+    const fakeElement = DOM.createElement('fakeelement') as HTMLElement;
+    let propertyName: string | undefined;
+    // tslint:disable-next-line:no-conditional-assignment
+    while (propertyName = propertyNames.pop()) {
+      if (propertyName in fakeElement.style) {
+        return durationPropertyName = propertyName || null;
+      }
+    }
+    return durationPropertyName = null;
+  };
+})();
+const body = DOM.querySelectorAll('body')[0] as HTMLBodyElement;
+
+describe('DialogRenderer', () => {
+  function createRenderer(settings: DialogSettings = {}): TestDialogRenderer {
+    const renderer = new NativeDialogRenderer() as TestDialogRenderer;
+    renderer.getDialogContainer();
+    const dialogController = jasmine.createSpyObj('DialogControllerSpy', ['cancel', 'ok']) as DialogController;
+    (dialogController.cancel as jasmine.Spy)
+      .and
+      .callFake((...args: any[]) => dialogController.renderer.hideDialog(dialogController));
+    (dialogController.ok as jasmine.Spy)
+      .and
+      .callFake((...args: any[]) => dialogController.renderer.hideDialog(dialogController));
+    dialogController.settings = Object.assign(new DefaultDialogSettings(), settings);
+    dialogController.renderer = renderer;
+    dialogController.controller = jasmine.createSpyObj('ControllerSpy', ['attached', 'detached']);
+    renderer.__controller = dialogController;
+    return renderer as any;
+  }
+
+  async function showOrHide(action: 'showDialog' | 'hideDialog', done: DoneFn, ...rendereres: TestDialogRenderer[]) {
+    try {
+      await Promise.all(rendereres.map(renderer => renderer[action](renderer.__controller)));
+    } catch (e) {
+      done.fail(e);
+      throw e;
+    }
+  }
+
+  function show(done: DoneFn, ...rendereres: TestDialogRenderer[]) {
+    return showOrHide('showDialog', done, ...rendereres);
+  }
+
+  function hide(done: DoneFn, ...rendereres: TestDialogRenderer[]) {
+    return showOrHide('hideDialog', done, ...rendereres);
+  }
+
+  function cleanDOM(): void {
+    NativeDialogRenderer.dialogControllers.forEach(controller => {
+      const { dialogContainer } = controller.renderer as NativeDialogRenderer;
+      if (dialogContainer && dialogContainer.parentElement) {
+        dialogContainer.parentElement.removeChild(dialogContainer);
+      }
+    });
+    NativeDialogRenderer.dialogControllers = [];
+  }
+
+  afterEach(() => {
+    cleanDOM();
+  });
+
+  describe('honours the setting', () => {
+    describe('"postion"', () => {
+      it('and calls when provided', async done => {
+        const renderer = createRenderer({ position: jasmine.createSpy('postionSpy') });
+        await show(done, renderer);
+        expect(renderer.__controller.settings.position)
+          .toHaveBeenCalledWith(renderer.dialogContainer);
+        done();
+      });
+    });
+
+    describe('"keyboard"', () => {
+      it('and does nothing when it is "false"', async done => {
+        const settings: DialogSettings = { keyboard: false };
+        const first = createRenderer(settings);
+        const last = createRenderer(settings);
+        await show(done, first, last);
+        first.dialogContainer.dispatchEvent(new Event('cancel'));
+        last.dialogContainer.dispatchEvent(new Event('cancel'));
+        expect(first.__controller.cancel).not.toHaveBeenCalled();
+        expect(last.__controller.cancel).not.toHaveBeenCalled();
+        done();
+      });
+
+      describe('and closes with cancel', () => {
+        async function closeOnEscSpec(done: DoneFn, settings: DialogSettings) {
+          const renderer = createRenderer(settings);
+          await show(done, renderer);
+          renderer.dialogContainer.dispatchEvent(new Event('cancel'));
+          expect(renderer.__controller.cancel).toHaveBeenCalled();
+          done();
+        }
+
+        it('when set to "true"', done => {
+          closeOnEscSpec(done, { keyboard: true });
+        });
+
+        it('when set to "Escape"', done => {
+          closeOnEscSpec(done, { keyboard: 'Escape' });
+        });
+
+        it('when set to an array containing "Escape"', done => {
+          closeOnEscSpec(done, { keyboard: ['Escape'] });
+        });
+      });
+
+      describe('and closes with ok', () => {
+        async function closeOnEscSpec(done: DoneFn, settings: DialogSettings) {
+          const renderer = createRenderer(settings);
+          await show(done, renderer);
+          DOM.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+          expect(renderer.__controller.ok).toHaveBeenCalled();
+          done();
+        }
+
+        it('when set to "Enter"', done => {
+          closeOnEscSpec(done, { keyboard: 'Enter' });
+        });
+
+        it('when set to an array containing "Enter"', done => {
+          closeOnEscSpec(done, { keyboard: ['Enter'] });
+        });
+      });
+    });
+
+    describe('"backdropDismiss"', () => {
+      it('set to "false" by not closing the dialog when clicked outside it', async done => {
+        const settings: DialogSettings = { overlayDismiss: false };
+        const renderer = createRenderer(settings);
+        await show(done, renderer);
+        renderer.dialogContainer.dispatchEvent(new MouseEvent('click'));
+        expect(renderer.__controller.cancel).not.toHaveBeenCalled();
+        done();
+      });
+
+      it('set to "true" by closing the dialog when clicked outside it', async done => {
+        const settings: DialogSettings = { overlayDismiss: true };
+        const renderer = createRenderer(settings);
+        await show(done, renderer);
+        renderer.dialogContainer.dispatchEvent(new MouseEvent('click'));
+        expect(renderer.__controller.cancel).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    describe('"host"', () => {
+      it('and when provided parents the dialog', async done => {
+        const host = DOM.createElement('div');
+        spyOn(host, 'insertBefore').and.callThrough();
+        spyOn(host, 'removeChild').and.callThrough();
+        body.appendChild(host);
+        const settings: DialogSettings = { host };
+        const renderer = createRenderer(settings);
+        await show(done, renderer);
+        expect(host.insertBefore).toHaveBeenCalledWith(renderer.dialogContainer, null);
+        await hide(done, renderer);
+        expect(host.removeChild).toHaveBeenCalledWith(renderer.dialogContainer);
+        body.removeChild(host);
+        done();
+      });
+
+      it('and when missing defaults to the "body" element', async done => {
+        const renderer = createRenderer({ host: undefined });
+        await show(done, renderer);
+        expect(renderer.host).toBe(body);
+        done();
+      });
+    });
+  });
+
+  describe('on first open dialog', () => {
+    beforeEach(() => {
+      expect(NativeDialogRenderer.dialogControllers.length).toBe(0);
+    });
+
+    it('adds "ux-dialog-open" class to the dialog host', async done => {
+      spyOn(body.classList, 'add').and.callThrough();
+      const renderer = createRenderer();
+      await show(done, renderer);
+      expect(body.classList.add).toHaveBeenCalled();
+      done();
+    });
+
+    it('sets ESC key event handler', async done => {
+      spyOn(DOM, 'addEventListener');
+      const first = createRenderer();
+      const last = createRenderer();
+      await show(done, first, last);
+      expect(DOM.addEventListener).toHaveBeenCalledWith('keyup', jasmine.any(Function), false);
+      expect((DOM.addEventListener as jasmine.Spy).calls.count()).toBe(1);
+      expect(NativeDialogRenderer.dialogControllers.length).toBe(2);
+      done();
+    });
+  });
+
+  describe('on last closed dialog', () => {
+    let renderers: TestDialogRenderer[];
+
+    beforeEach(async done => {
+      expect(NativeDialogRenderer.dialogControllers.length).toBe(0);
+      renderers = [createRenderer(), createRenderer()];
+      await show(done, ...renderers);
+      done();
+    });
+
+    afterEach(() => {
+      expect(NativeDialogRenderer.dialogControllers.length).toBe(0);
+    });
+
+    it('removes "ux-dialog-open" class from the dialog host', async done => {
+      spyOn(body.classList, 'remove').and.callThrough();
+      await hide(done, ...renderers);
+      expect(body.classList.remove).toHaveBeenCalled();
+      done();
+    });
+
+    it('removes ESC key event handler', async done => {
+      spyOn(DOM, 'removeEventListener');
+      await hide(done, ...renderers);
+      expect(DOM.removeEventListener).toHaveBeenCalledWith('keyup', jasmine.any(Function), false);
+      expect((DOM.removeEventListener as jasmine.Spy).calls.count()).toBe(1);
+      done();
+    });
+  });
+
+  describe('on not last closed dialog', () => {
+    let renderer: TestDialogRenderer;
+
+    beforeEach(async done => {
+      expect(NativeDialogRenderer.dialogControllers.length).toBe(0);
+      await show(done, createRenderer(), renderer = createRenderer(), createRenderer());
+      done();
+    });
+
+    afterEach(() => {
+      expect(NativeDialogRenderer.dialogControllers.length).toBe(2);
+    });
+
+    it('does not remove "ux-dialog-open" from the dialog host', async done => {
+      spyOn(body.classList, 'remove').and.callThrough();
+      await hide(done, renderer);
+      expect(body.classList.remove).not.toHaveBeenCalled();
+      done();
+    });
+
+    it('does not remove the ESC key event handler', async done => {
+      spyOn(DOM, 'removeEventListener');
+      await hide(done, renderer);
+      expect(DOM.removeEventListener).not.toHaveBeenCalledWith('keyup', jasmine.any(Function), false);
+      expect((DOM.removeEventListener as jasmine.Spy).calls.count()).toBe(0);
+      done();
+    });
+  });
+
+  describe('accounts for transitions', () => {
+    let renderer: TestDialogRenderer;
+    let transitionDuration: string;
+
+    beforeEach(() => {
+      renderer = createRenderer();
+      spyOn(renderer, 'setAsActive').and.callFake(() => { // transition trigger
+        renderer.dialogContainer.style.opacity = '1';
+      });
+      spyOn(renderer, 'setAsInactive').and.callFake(() => { // transition trigger
+        renderer.dialogContainer.style.opacity = '0';
+      });
+      Object.defineProperty(renderer, 'dialogContainer', { // is set in ".showDialog()"
+        get: (): HTMLDialogElement => {
+          return this.dialogContainer;
+        },
+        set: (element: HTMLDialogElement): void => {
+          this.dialogContainer = element;
+          element.style[durationPropertyName() as any] = transitionDuration;
+          element.style.opacity = '0'; // init
+          spyOn(element, 'addEventListener').and.callThrough();
+        }
+      });
+    });
+
+    describe('and when "inoreTransitions" is set to "true"', () => {
+      it('"showDialog" does not wait', async done => {
+        renderer.__controller.settings.ignoreTransitions = true;
+        transitionDuration = '1s';
+        await show(done, renderer);
+        expect(renderer.dialogContainer.addEventListener)
+          .not.toHaveBeenCalledWith(transitionEvent(), jasmine.any(Function));
+        done();
+      });
+
+      it('"hideDialog" does not wait', async done => {
+        renderer.__controller.settings.ignoreTransitions = true;
+        transitionDuration = '1s';
+        await show(done, renderer);
+        spyOn(renderer.dialogContainer, 'removeEventListener').and.callThrough();
+        await hide(done, renderer);
+        expect(renderer.dialogContainer.removeEventListener)
+          .not.toHaveBeenCalledWith(transitionEvent(), jasmine.any(Function));
+        done();
+      });
+    });
+
+    describe('and when the transition duration is zero', () => {
+      it('"showDialog" does not await', async done => {
+        renderer.__controller.settings.ignoreTransitions = false;
+        transitionDuration = '0s';
+        await show(done, renderer);
+        expect(renderer.dialogContainer.addEventListener)
+          .not.toHaveBeenCalledWith(transitionEvent(), jasmine.any(Function));
+        done();
+      });
+
+      it('"hideDialog" does not await', async done => {
+        renderer.__controller.settings.ignoreTransitions = false;
+        transitionDuration = '0s';
+        await show(done, renderer);
+        spyOn(renderer.dialogContainer, 'removeEventListener').and.callThrough();
+        await hide(done, renderer);
+        expect(renderer.dialogContainer.removeEventListener)
+          .not.toHaveBeenCalledWith(transitionEvent(), jasmine.any(Function));
+        done();
+      });
+    });
+  });
+
+  describe('"backdropDismiss" handlers', () => {
+    it('do not stop events propagation', async done => {
+      const renderer = createRenderer();
+      const event = new MouseEvent('click');
+      spyOn(event, 'stopPropagation').and.callThrough();
+      spyOn(event, 'stopImmediatePropagation').and.callThrough();
+      await show(done, renderer);
+      renderer.dialogContainer.dispatchEvent(event);
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+      expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+      done();
+    });
+
+    it('do not cancel events', async done => {
+      const renderer = createRenderer();
+      const event = new MouseEvent('click');
+      spyOn(event, 'preventDefault').and.callThrough();
+      await show(done, renderer);
+      renderer.dialogContainer.dispatchEvent(event);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      done();
+    });
+  });
+});
+
+describe('"hasTransition"', () => {
+  let element: HTMLElement;
+
+  function skip(): boolean {
+    if (durationPropertyName()) { return false; }
+    pending('Skipped because css transitions are not supported.');
+    return true;
+  }
+
+  beforeEach(() => {
+    if (skip()) { return; }
+    element = DOM.createElement('duration-test-element') as any;
+    body.insertBefore(element, body.firstChild);
+  });
+
+  afterEach(() => {
+    if (!durationPropertyName()) { return; }
+    body.removeChild(element);
+  });
+
+  it('reports "true" for non zero duration transitions set in styles', () => {
+    const prefixes = ['-moz-', '-webkit-', '-o-', ''];
+    const transitionProperty = 'transition';
+    const testClass = 'transition-test-class';
+    // tslint:disable-next-line:max-line-length
+    const styles = `.${testClass} {${prefixes.map(prefix => `${prefix}${transitionProperty}: opacity .2s linear;`).join('')}}`;
+    DOM.injectStyles(styles);
+    element.classList.add(testClass);
+    expect(hasTransition(element)).toBe(true);
+  });
+
+  it('reports "true" for non zero duration transitions set in code', () => {
+    const duration = '0.2s';
+    (element.style as any)[durationPropertyName() as string] = duration;
+    expect(hasTransition(element)).toBe(true);
+  });
+
+  it('reports "true" for zero and non-zero transitions', () => {
+    const duration = '0s, 0.3s';
+    (element.style as any)[durationPropertyName() as string] = duration;
+    expect(hasTransition(element)).toBe(true);
+  });
+
+  it('reports "false" for zero duration transition', () => {
+    expect(hasTransition(element)).toBe(false);
+  });
+});


### PR DESCRIPTION
I wont repeat [everything I've already said in #335](https://github.com/aurelia/dialog/issues/335#issuecomment-359568900). 

This would finally close #1 and improve accessabilty.

**Breaking Changes**
- ~~`startingZIndex` setting is no longer required~~
- `position` callback is no longer passed overlay element as it no longer exists
- `centerHorizontalOnly` is not used. CSS only.

**To do**
- [x] Test that everything all works in polyfilled browsers
  - [x] Karma tests pass in Firefox 58.0 (2 transition tests still failing)
  - [x] Test real world usage in some other browsers
