### PR TITLE
Trucante long text in display table

### DIFF
--- a/styles/input.less
+++ b/styles/input.less
@@ -55,6 +55,7 @@ ai-dialog-container {
 ai-dialog {
   width: 100%;
   display: table;
+  table-layout: fixed;
   box-shadow: 0 5px 15px rgba(0,0,0,.5);
   border: 1px solid rgba(0,0,0,.2);
   border-radius: 5px;


### PR DESCRIPTION
The table should not grow outside the width of the screen, if displays text (potentially long), which must be truncated when necessary, so that the text fits into the child elements, which is adapted to the width of the table, which may not be larger than the width of the screen.

[bad](https://codepen.io/victorDivino/pen/MVyrag)
[fix](https://codepen.io/victorDivino/pen/gerowj)