### PR TITLE
fix attach-focus for dynamic change

### DIFF
--- a/src/attach-focus.ts
+++ b/src/attach-focus.ts
@@ -22,5 +22,8 @@ export class AttachFocus implements ComponentAttached {
 
   public valueChanged(newValue: string) {
     this.value = newValue;
+    if (this.value && this.value !== 'false') {
+      this.element.focus();
+    }
   }
 }


### PR DESCRIPTION
This fixes an issue that the focus did not move when JS changed focusedIndex in the following example.

```
<li repeat.for="index of keywords">
  <input attach-focus.bind="focusedIndex === index">
```