### PR TITLE
feat(all): support non-modal dialogs

### DIFF
--- a/src/dialog-renderer-default.ts
+++ b/src/dialog-renderer-default.ts
@@ -73,7 +73,12 @@ export class DialogRendererDefault implements Renderer {
   }
 
   private setupClickDismissHandling(dialogController: InfrastructureDialogController): void {
-    this.contentInboundClick = eo => { eo[CONTENT_INBOUND_CLICK] = true; };
+    this.contentInboundClick = eo => {
+      // TODO: if (!dialogController.settings.modal) {
+      //   set as focused
+      // }
+      eo[CONTENT_INBOUND_CLICK] = true;
+    };
     this.contentOutboundClick = eo => {
       if (dialogController.settings.overlayDismiss && !eo[CONTENT_INBOUND_CLICK]) {
         dialogController.cancel();

--- a/src/dialog-settings.ts
+++ b/src/dialog-settings.ts
@@ -24,6 +24,8 @@ export interface DialogSettings {
    */
   model?: any;
 
+  modal?: boolean;
+
   /**
    * The element that will parent the dialog.
    */
@@ -95,5 +97,6 @@ export class DefaultDialogSettings implements DialogSettings {
   public centerHorizontalOnly = false;
   public rejectOnCancel = false;
   public ignoreTransitions = false;
+  public modal = true;
   public position?: (dialogContainer: Element, dialogOverlay: Element) => void;
 }


### PR DESCRIPTION
I'm proposing to support non-modal dialogs - the native dialogs support it.
1. A **modal dialog** is always *on top*(visually)
    - `Renderer`s will have to append any **non-modal dialog** before existing **modal** ones in the *host*
    - the `DialogService` `.controllers` property will still keep the controllers in the order they were open
2. Introduce a *focused* concept - the dialog the user is currently interacting with(*accepting naming propositions*)
    - apply actions on the *focused* dialog
        - whether or not and on which dialog, to apply the **keyboard** actions when there are only **non-modal dialogs**
    - the top **modal dialog** is always the *focused*
    - when there are no **modal dialogs** open there **may** or may **not** be a *focused* dialog

Did just minor changes to start a discussion.
@EisenbergEffect @PWKad what do you think?