### PR TITLE
Use fixed versions in typings.json

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -2,9 +2,9 @@
   "name": "aurelia-dialog",
   "main": "dist/commonjs/aurelia-dialog.d.ts",
   "dependencies": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection",
-      "aurelia-metadata": "github:aurelia/metadata",
-      "aurelia-pal": "github:aurelia/pal",
-      "aurelia-templating": "github:aurelia/templating"    
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection#1.3.2",
+      "aurelia-metadata": "github:aurelia/metadata#1.0.4",
+      "aurelia-pal": "github:aurelia/pal#1.8.0",
+      "aurelia-templating": "github:aurelia/templating#1.7.0"    
   }
 }


### PR DESCRIPTION
Using the always the latest version leads to unstable builds. Currently, all projects that use TS and the `aurelia-dialog` fails to build because of [the breaking change in the `aurelia-dependency-inection` v1.4.0](https://github.com/aurelia/dependency-injection/issues/166#issuecomment-397985431).