### PR TITLE
fix(build): adjust umd build, add umd-es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "license": "MIT",
   "author": "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)",
   "main": "dist/commonjs/aurelia-dialog.js",
-  "module": "dist/es2015/aurelia-dialog.js",
+  "module": "dist/native-modules/aurelia-dialog.js",
   "browser": "dist/umd/aurelia-dialog.js",
-  "unpkg": "dist/umd/aurelia-dialog.js",
+  "unpkg": "dist/umd-es2015/aurelia-dialog.js",
   "typings": "dist/commonjs/aurelia-dialog.d.ts",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,45 +1,90 @@
 import typescript from 'rollup-plugin-typescript2';
 
-export default {
-  input: './src/aurelia-dialog.ts',
-  external: [
-    'aurelia-framework',
-    'aurelia-binding',
-    'aurelia-templating',
-    'aurelia-dependency-injection',
-    'aurelia-pal'
-  ],
-  output: [
-    {
-      file: 'dist/umd/aurelia-dialog.js',
-      format: 'umd',
-      name: 'au.dialog',
-      globals: {
-        'aurelia-framework': 'au',
-        'aurelia-binding': 'au',
-        'aurelia-templating': 'au',
-        'aurelia-dependency-injection': 'au',
-        'aurelia-pal': 'au'
-      },
-      esModule: false
-    }
-  ],
-  inlineDynamicImports: true,
-  plugins: [
-    typescript({
-      tsconfigOverride: {
-        compilerOptions: {
-          module: 'esnext',
-          outDir: undefined,
-          target: 'es2015',
-          declaration: false,
-          removeComments: true
+export default [
+  {
+    input: './src/aurelia-dialog.ts',
+    external: [
+      'aurelia-framework',
+      'aurelia-binding',
+      'aurelia-templating',
+      'aurelia-dependency-injection',
+      'aurelia-pal'
+    ],
+    output: [
+      {
+        file: 'dist/umd/aurelia-dialog.js',
+        format: 'umd',
+        name: 'au.dialog',
+        globals: {
+          'aurelia-framework': 'au',
+          'aurelia-binding': 'au',
+          'aurelia-templating': 'au',
+          'aurelia-dependency-injection': 'au',
+          'aurelia-pal': 'au'
         },
-        include: [
-          'src'
-        ]
-      },
-      cacheRoot: '.rollupcache'
-    })
-  ]
-}
+        esModule: false
+      }
+    ],
+    inlineDynamicImports: true,
+    plugins: [
+      typescript({
+        tsconfigOverride: {
+          compilerOptions: {
+            module: 'esnext',
+            outDir: undefined,
+            target: 'es5',
+            declaration: false,
+            removeComments: true
+          },
+          include: [
+            'src'
+          ]
+        },
+        cacheRoot: '.rollupcache'
+      })
+    ]
+  },
+  {
+    input: './src/aurelia-dialog.ts',
+    external: [
+      'aurelia-framework',
+      'aurelia-binding',
+      'aurelia-templating',
+      'aurelia-dependency-injection',
+      'aurelia-pal'
+    ],
+    output: [
+      {
+        file: 'dist/umd-es2015/aurelia-dialog.js',
+        format: 'umd',
+        name: 'au.dialog',
+        globals: {
+          'aurelia-framework': 'au',
+          'aurelia-binding': 'au',
+          'aurelia-templating': 'au',
+          'aurelia-dependency-injection': 'au',
+          'aurelia-pal': 'au'
+        },
+        esModule: false
+      }
+    ],
+    inlineDynamicImports: true,
+    plugins: [
+      typescript({
+        tsconfigOverride: {
+          compilerOptions: {
+            module: 'esnext',
+            outDir: undefined,
+            target: 'es2015',
+            declaration: false,
+            removeComments: true
+          },
+          include: [
+            'src'
+          ]
+        },
+        cacheRoot: '.rollupcache'
+      })
+    ]
+  }
+]


### PR DESCRIPTION
@fkleuver @huochunpeng @EisenbergEffect @StrahilKazlachev 

This PR adds an additional build target: `umd-es2015` for the combination of umd module format and es2015 version. Also adjust package.json so it won't cause any issues with IE11 when used without transpilation by pointing `module` field in package.json to `native-modules`
