### PR TITLE
fix(attach-focus): focus the element as injected

### DIFF
--- a/src/resources/attach-focus.ts
+++ b/src/resources/attach-focus.ts
@@ -23,6 +23,7 @@ export class AttachFocus implements ComponentAttached {
 
   constructor(private element: HTMLElement) {
     this.value = true;
+    this.element = element;
   }
 
   public attached(): void {


### PR DESCRIPTION
If we don't store the element reference on the class, then the attach focus attribute will do nothing.